### PR TITLE
[anodized-core] refactor: parse `Specified` AST nodes

### DIFF
--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -19,21 +19,67 @@ use syntax::Keyword;
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
 
+pub trait Specify: Sized {
+    type Spec;
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
+}
+
+impl Specify for ItemFn {
+    type Spec = FnSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = syn::parse2(input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl Specify for ImplItemFn {
+    type Spec = FnSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = syn::parse2(input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl Specify for TraitItemFn {
+    type Spec = FnSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = syn::parse2(input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl Specify for ItemStruct {
+    type Spec = DataSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = syn::parse2(input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl Specify for ItemEnum {
+    type Spec = DataSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = syn::parse2(input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
 pub trait ParseOnItem<Item>: Sized {
     fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self>;
 }
 
-impl<Spec: Parse, Item: Parse> ParseOnItem<Item> for SpecItem<Spec, Item> {
+impl<Item: Specify> ParseOnItem<Item> for SpecItem<Item::Spec, Item> {
     fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self> {
-        let spec = syn::parse2(spec_input)?;
-        Ok(SpecItem { spec, item })
+        item.parse_spec(spec_input)
     }
 }
 
-impl<Spec, Item: Parse + Spanned + HasAttrs> Parse for SpecItem<Spec, Item>
-where
-    SpecItem<Spec, Item>: ParseOnItem<Item>,
-{
+impl<Item: Parse + HasAttrs + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: Item = input.parse()?;
         let Some(attr) = remove_spec_attr(item.get_attrs_mut())? else {
@@ -43,7 +89,7 @@ where
             ));
         };
         let spec_input = get_attr_input(attr)?;
-        Self::parse_spec_on(item, spec_input)
+        item.parse_spec(spec_input)
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,7 +8,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition, SpecItem,
+    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, NodeWithSpec, PostCondition,
     annotate::syntax::SpecFields, qualifiers::FnQualifiers,
 };
 
@@ -19,9 +19,9 @@ use syntax::Keyword;
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
 
-/// Implemented by AST node types that may have a `#[spec]` attribute.
-pub trait Specify: Sized {
-    /// The type of the spec associated with this AST node type.
+/// Implemented by AST nodes that may have a `#[spec]` attribute.
+pub trait Specified: Sized {
+    /// The spec type associated with this AST node.
     type Spec;
 
     /// Attach the `#[spec]` from the `Attribute` list.
@@ -30,7 +30,7 @@ pub trait Specify: Sized {
     ///     and its contents are parsed as `Self::Spec`, then attached to the AST node.
     /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
     /// - Multiple `#[spec]` attributes are not allowed and cause an error.
-    fn with_spec_attr(mut self) -> Result<SpecItem<Self::Spec, Self>>
+    fn with_spec_from_attrs(mut self) -> Result<NodeWithSpec<Self::Spec, Self>>
     where
         Self: Spanned,
     {
@@ -40,111 +40,115 @@ pub trait Specify: Sized {
             TokenStream::new()
         };
         let spec_fields: SpecFields = syn::parse2(spec_input)?;
-        self.with_spec_parse(spec_fields)
+        self.with_spec_from_fields(spec_fields)
     }
 
-    /// Attach the `#[spec]` by parsing it from a `TokenStream`.
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>>;
+    /// Attach the `#[spec]` by parsing it from `SpecFields`.
+    ///
+    /// Implement this to parse a spec in the context of its AST node.
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>>;
 
     /// Get a mutable reference to the `Attribute` list.
+    ///
+    /// Needed to by the default `with_spec_from_attrs`.
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
 }
 
-impl<Item: Parse + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
+impl<AstNode: Parse + Spanned + Specified> Parse for NodeWithSpec<AstNode::Spec, AstNode> {
     fn parse(input: ParseStream) -> Result<Self> {
-        let item: Item = input.parse()?;
-        item.with_spec_attr()
+        let item: AstNode = input.parse()?;
+        item.with_spec_from_attrs()
     }
 }
 
-impl Specify for ItemFn {
+impl Specified for ItemFn {
     type Spec = FnSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for ImplItemFn {
+impl Specified for ImplItemFn {
     type Spec = FnSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for TraitItemFn {
+impl Specified for TraitItemFn {
     type Spec = FnSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for ItemStruct {
+impl Specified for ItemStruct {
     type Spec = DataSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for ItemEnum {
+impl Specified for ItemEnum {
     type Spec = DataSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for ItemImpl {
+impl Specified for ItemImpl {
     type Spec = DataSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 
-impl Specify for ItemTrait {
+impl Specified for ItemTrait {
     type Spec = DataSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
         let spec = fields.try_into()?;
-        Ok(SpecItem { spec, item: self })
+        Ok(NodeWithSpec { spec, node: self })
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, ImplItemFn, ItemEnum,
-    ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, Path, TraitItemFn, parse::Result, parse_quote,
+    ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, TraitItemFn, parse::Result, parse_quote,
     spanned::Spanned,
 };
 
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub mod syntax;
-use syntax::Keyword;
+use syntax::{Keyword, get_attr_input, remove_spec_attr};
 
 #[cfg(test)]
 #[path = "annotate_tests.rs"]
@@ -85,30 +85,6 @@ impl Specified for TraitItemFn {
     }
 }
 
-impl Specified for ItemStruct {
-    type Spec = DataSpec;
-
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-
-    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
-    }
-}
-
-impl Specified for ItemEnum {
-    type Spec = DataSpec;
-
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-
-    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
-    }
-}
-
 impl Specified for ItemImpl {
     type Spec = DataSpec;
 
@@ -122,6 +98,30 @@ impl Specified for ItemImpl {
 }
 
 impl Specified for ItemTrait {
+    type Spec = DataSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
+    }
+}
+
+impl Specified for ItemStruct {
+    type Spec = DataSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
+    }
+}
+
+impl Specified for ItemEnum {
     type Spec = DataSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
@@ -154,50 +154,6 @@ impl Specified for ExprWhile {
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
-    }
-}
-
-/// Removes a single `#[spec]` attribute, if present, from an attribute list.
-///
-/// If there are multiple `#[spec]` attributes, returns `Err`.
-/// The arguments of the `#[spec]` attribute are *not* validated.
-pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
-    let mut maybe_index = None;
-
-    for (i, attr) in attrs
-        .iter()
-        .enumerate()
-        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
-    {
-        if maybe_index.is_some() {
-            return Err(Error::new_spanned(
-                attr,
-                "multiple `#[spec]` attributes are not allowed",
-            ));
-        }
-        maybe_index = Some(i);
-    }
-
-    if let Some(index) = maybe_index {
-        let attr = attrs.remove(index);
-        Ok(Some(attr))
-    } else {
-        Ok(None)
-    }
-}
-
-fn path_matches_name(path: &Path, name: &str) -> bool {
-    path.get_ident().is_some_and(|ident| *ident == name)
-}
-
-pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
-    match attr.meta {
-        Meta::Path(_) => Ok(TokenStream::new()),
-        Meta::List(list) => Ok(list.tokens),
-        Meta::NameValue(key_value) => Err(Error::new_spanned(
-            key_value.eq_token,
-            "expected arguments between delimiters `()`, `[]`, or `{}`",
-        )),
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,8 +8,8 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecEnumItem,
-    SpecImplItemFn, SpecItemFn, SpecItemStruct, SpecTraitItemFn, qualifiers::FnQualifiers,
+    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecImplItemFn,
+    SpecItemEnum, SpecItemFn, SpecItemStruct, SpecTraitItemFn, qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -103,14 +103,14 @@ impl Parse for SpecItemStruct {
     }
 }
 
-impl SpecEnumItem {
+impl SpecItemEnum {
     pub fn parse_spec_on(item: ItemEnum, spec_input: TokenStream) -> Result<Self> {
         let spec = syn::parse2(spec_input)?;
-        Ok(SpecEnumItem { spec, item })
+        Ok(SpecItemEnum { spec, item })
     }
 }
 
-impl Parse for SpecEnumItem {
+impl Parse for SpecItemEnum {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: ItemEnum = input.parse()?;
         let Some(attr) = remove_spec_attr(&mut item.attrs)? else {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -2,14 +2,14 @@ use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemImpl,
     ItemStruct, ItemTrait, Meta, Path, TraitItemFn,
-    parse::{Parse, ParseStream, Parser, Result},
+    parse::{Parse, ParseStream, Result},
     parse_quote,
     spanned::Spanned,
 };
 
 use crate::{
     Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition, SpecItem,
-    qualifiers::FnQualifiers,
+    annotate::syntax::SpecFields, qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -34,16 +34,17 @@ pub trait Specify: Sized {
     where
         Self: Spanned,
     {
-        let spec_input = if let Some(attr) = remove_spec_attr(self.get_attrs_mut())? {
+        let spec_input: TokenStream = if let Some(attr) = remove_spec_attr(self.get_attrs_mut())? {
             get_attr_input(attr)?
         } else {
             TokenStream::new()
         };
-        self.with_spec_parse(spec_input)
+        let spec_fields: SpecFields = syn::parse2(spec_input)?;
+        self.with_spec_parse(spec_fields)
     }
 
     /// Attach the `#[spec]` by parsing it from a `TokenStream`.
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>>;
 
     /// Get a mutable reference to the `Attribute` list.
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
@@ -63,8 +64,8 @@ impl Specify for ItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(FnSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -76,8 +77,8 @@ impl Specify for ImplItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(FnSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -89,8 +90,8 @@ impl Specify for TraitItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(FnSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -102,8 +103,8 @@ impl Specify for ItemStruct {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(DataSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -115,8 +116,8 @@ impl Specify for ItemEnum {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(DataSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -128,8 +129,8 @@ impl Specify for ItemImpl {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(DataSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -141,8 +142,8 @@ impl Specify for ItemTrait {
         &mut self.attrs
     }
 
-    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(DataSpec::parse, input)?;
+    fn with_spec_parse(self, fields: SpecFields) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = fields.try_into()?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -191,9 +192,11 @@ pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
     }
 }
 
-impl FnSpec {
-    fn parse(input: ParseStream) -> Result<FnSpec> {
-        let raw_spec = syntax::SpecFields::parse(input)?;
+impl TryFrom<SpecFields> for FnSpec {
+    type Error = Error;
+
+    fn try_from(raw_spec: SpecFields) -> Result<FnSpec> {
+        let span = raw_spec.span();
 
         let mut errors = MultiError::empty();
         let mut qualifiers = FnQualifiers::empty();
@@ -300,7 +303,7 @@ impl FnSpec {
 
         if !is_sorted {
             errors.add(Error::new(
-                input.span(),
+                span,
                 "fields are out of order: the expected order is: `<QUALIFIERS>`, `requires`, `maintains`, `captures`, `inspects`, `ensures`, where `<QUALIFIERS>` are:\n
 `functional` (`pure` and `total`),\n
 `pure` (`deterministic` and `effectfree`),\n
@@ -318,14 +321,16 @@ impl FnSpec {
             maintains,
             captures,
             ensures,
-            span: input.span(),
+            span,
         })
     }
 }
 
-impl DataSpec {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let raw_spec = syntax::SpecFields::parse(input)?;
+impl TryFrom<SpecFields> for DataSpec {
+    type Error = Error;
+
+    fn try_from(raw_spec: SpecFields) -> Result<Self> {
+        let span = raw_spec.span();
 
         let mut errors = MultiError::empty();
         let mut maintains: Vec<Condition> = vec![];
@@ -351,10 +356,7 @@ impl DataSpec {
             return Err(combined_error);
         }
 
-        Ok(Self {
-            maintains,
-            span: input.span(),
-        })
+        Ok(Self { maintains, span })
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,8 +8,8 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition, SpecImplItemFn,
-    SpecItemEnum, SpecItemFn, SpecItemStruct, SpecTraitItemFn, qualifiers::FnQualifiers,
+    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition, SpecItem,
+    qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -19,20 +19,27 @@ use syntax::Keyword;
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
 
-impl SpecItemFn {
-    pub fn parse_spec_on(item: ItemFn, spec_input: TokenStream) -> Result<Self> {
+pub trait ParseOnItem<Item>: Sized {
+    fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self>;
+}
+
+impl<Spec: Parse, Item: Parse> ParseOnItem<Item> for SpecItem<Spec, Item> {
+    fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self> {
         let spec = syn::parse2(spec_input)?;
-        Ok(SpecItemFn { spec, item })
+        Ok(SpecItem { spec, item })
     }
 }
 
-impl Parse for SpecItemFn {
+impl<Spec, Item: Parse + Spanned + HasAttrs> Parse for SpecItem<Spec, Item>
+where
+    SpecItem<Spec, Item>: ParseOnItem<Item>,
+{
     fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: ItemFn = input.parse()?;
-        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
-            return Err(Error::new_spanned(
-                item,
-                "expected a `#[spec]` attribute on this `fn`",
+        let mut item: Item = input.parse()?;
+        let Some(attr) = remove_spec_attr(item.get_attrs_mut())? else {
+            return Err(Error::new(
+                item.span(),
+                "expected a `#[spec]` attribute on this item",
             ));
         };
         let spec_input = get_attr_input(attr)?;
@@ -40,87 +47,37 @@ impl Parse for SpecItemFn {
     }
 }
 
-impl SpecImplItemFn {
-    pub fn parse_spec_on(item: ImplItemFn, spec_input: TokenStream) -> Result<Self> {
-        let spec = syn::parse2(spec_input)?;
-        Ok(SpecImplItemFn { spec, item })
+trait HasAttrs {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
+}
+
+impl HasAttrs for ItemFn {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
 }
 
-impl Parse for SpecImplItemFn {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: ImplItemFn = input.parse()?;
-        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
-            return Err(Error::new_spanned(
-                item,
-                "expected a `#[spec]` attribute on this `fn`",
-            ));
-        };
-        let spec_input = get_attr_input(attr)?;
-        Self::parse_spec_on(item, spec_input)
+impl HasAttrs for ImplItemFn {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
 }
 
-impl SpecTraitItemFn {
-    pub fn parse_spec_on(item: TraitItemFn, spec_input: TokenStream) -> Result<Self> {
-        let spec = syn::parse2(spec_input)?;
-        Ok(SpecTraitItemFn { spec, item })
+impl HasAttrs for TraitItemFn {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
 }
 
-impl Parse for SpecTraitItemFn {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: TraitItemFn = input.parse()?;
-        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
-            return Err(Error::new_spanned(
-                item,
-                "expected a `#[spec]` attribute on this `fn`",
-            ));
-        };
-        let spec_input = get_attr_input(attr)?;
-        Self::parse_spec_on(item, spec_input)
+impl HasAttrs for ItemStruct {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
 }
 
-impl SpecItemStruct {
-    pub fn parse_spec_on(item: ItemStruct, spec_input: TokenStream) -> Result<Self> {
-        let spec = syn::parse2(spec_input)?;
-        Ok(SpecItemStruct { spec, item })
-    }
-}
-
-impl Parse for SpecItemStruct {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: ItemStruct = input.parse()?;
-        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
-            return Err(Error::new_spanned(
-                item,
-                "expected a `#[spec]` attribute on this `struct`",
-            ));
-        };
-        let spec_input = get_attr_input(attr)?;
-        Self::parse_spec_on(item, spec_input)
-    }
-}
-
-impl SpecItemEnum {
-    pub fn parse_spec_on(item: ItemEnum, spec_input: TokenStream) -> Result<Self> {
-        let spec = syn::parse2(spec_input)?;
-        Ok(SpecItemEnum { spec, item })
-    }
-}
-
-impl Parse for SpecItemEnum {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: ItemEnum = input.parse()?;
-        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
-            return Err(Error::new_spanned(
-                item,
-                "expected a `#[spec]` attribute on this `enum`",
-            ));
-        };
-        let spec_input = get_attr_input(attr)?;
-        Self::parse_spec_on(item, spec_input)
+impl HasAttrs for ItemEnum {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,12 +1,12 @@
 use syn::{
-    Attribute, Error, Expr, ExprAssign, FieldValue, Meta,
+    Attribute, Error, Expr, ExprAssign, FieldValue, ItemFn, Meta, Path,
     parse::{Parse, ParseStream, Result},
     parse_quote,
     spanned::Spanned,
 };
 
 use crate::{
-    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec,
+    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecItemFn,
     qualifiers::FnQualifiers,
 };
 
@@ -16,6 +16,69 @@ use syntax::Keyword;
 #[cfg(test)]
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
+
+impl Parse for SpecItemFn {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut item: ItemFn = input.parse()?;
+        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
+            return Err(Error::new_spanned(
+                item,
+                "expected a `#[spec]` attribute on this `fn`",
+            ));
+        };
+        let spec = attr.meta.try_into()?;
+        Ok(SpecItemFn { spec, item })
+    }
+}
+
+/// Removes a single `#[spec]` attribute, if present, from an attribute list.
+///
+/// If there are multiple `#[spec]` attributes, returns `Err`.
+/// The arguments of the `#[spec]` attribute are *not* validated.
+pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
+    let mut maybe_index = None;
+
+    for (i, attr) in attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
+    {
+        if maybe_index.is_some() {
+            return Err(Error::new_spanned(
+                attr,
+                "multiple `#[spec]` attributes are not allowed",
+            ));
+        }
+        maybe_index = Some(i);
+    }
+
+    if let Some(index) = maybe_index {
+        let attr = attrs.remove(index);
+        Ok(Some(attr))
+    } else {
+        Ok(None)
+    }
+}
+
+fn path_matches_name(path: &Path, name: &str) -> bool {
+    path.get_ident()
+        .is_some_and(|ident| ident.to_string() == name)
+}
+
+impl TryFrom<Meta> for Spec {
+    type Error = Error;
+
+    fn try_from(meta: Meta) -> Result<Self> {
+        match meta {
+            Meta::Path(_) => Ok(Spec::empty()),
+            Meta::List(list) => syn::parse2(list.tokens),
+            Meta::NameValue(key_value) => Err(Error::new_spanned(
+                key_value.eq_token,
+                "expected arguments between delimiters `()`, `[]`, or `{}`",
+            )),
+        }
+    }
+}
 
 impl Parse for Spec {
     fn parse(input: ParseStream) -> Result<Self> {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -24,13 +24,13 @@ pub trait Specified: Sized {
     /// The spec type associated with this AST node.
     type Spec;
 
-    /// Attach the `#[spec]` from the `Attribute` list.
+    /// Parse the `#[spec]` from the `Attribute` list.
     ///
     /// - If the AST node has a `#[spec]` attribute, it is removed from the `Attribute` list,
     ///     and its contents are parsed as `Self::Spec`, then attached to the AST node.
     /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
     /// - Multiple `#[spec]` attributes are not allowed and cause an error.
-    fn with_spec_from_attrs(mut self) -> Result<NodeWithSpec<Self::Spec, Self>>
+    fn with_spec_from_attrs(&mut self) -> Result<Self::Spec>
     where
         Self: Spanned,
     {
@@ -43,10 +43,10 @@ pub trait Specified: Sized {
         self.with_spec_from_fields(spec_fields)
     }
 
-    /// Attach the `#[spec]` by parsing it from `SpecFields`.
+    /// Parse the `#[spec]` from `SpecFields`.
     ///
     /// Implement this to parse a spec in the context of its AST node.
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>>;
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec>;
 
     /// Get a mutable reference to the `Attribute` list.
     ///
@@ -56,8 +56,9 @@ pub trait Specified: Sized {
 
 impl<AstNode: Parse + Spanned + Specified> Parse for NodeWithSpec<AstNode::Spec, AstNode> {
     fn parse(input: ParseStream) -> Result<Self> {
-        let item: AstNode = input.parse()?;
-        item.with_spec_from_attrs()
+        let mut node: AstNode = input.parse()?;
+        let spec = node.with_spec_from_attrs()?;
+        Ok(Self { spec, node })
     }
 }
 
@@ -68,9 +69,8 @@ impl Specified for ItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -81,9 +81,8 @@ impl Specified for ImplItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -94,9 +93,8 @@ impl Specified for TraitItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -107,9 +105,8 @@ impl Specified for ItemStruct {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -120,9 +117,8 @@ impl Specified for ItemEnum {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -133,9 +129,8 @@ impl Specified for ItemImpl {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 
@@ -146,9 +141,8 @@ impl Specified for ItemTrait {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(self, fields: SpecFields) -> Result<NodeWithSpec<Self::Spec, Self>> {
-        let spec = fields.try_into()?;
-        Ok(NodeWithSpec { spec, node: self })
+    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -155,7 +155,7 @@ pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>>
 
 fn path_matches_name(path: &Path, name: &str) -> bool {
     path.get_ident()
-        .is_some_and(|ident| ident.to_string() == name)
+        .is_some_and(|ident| *ident == name)
 }
 
 pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -21,11 +21,18 @@ mod annotate_tests;
 
 pub trait Specify: Sized {
     type Spec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
+
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
 }
 
 impl Specify for ItemFn {
     type Spec = FnSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
@@ -36,6 +43,10 @@ impl Specify for ItemFn {
 impl Specify for ImplItemFn {
     type Spec = FnSpec;
 
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
@@ -44,6 +55,10 @@ impl Specify for ImplItemFn {
 
 impl Specify for TraitItemFn {
     type Spec = FnSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
@@ -54,6 +69,10 @@ impl Specify for TraitItemFn {
 impl Specify for ItemStruct {
     type Spec = DataSpec;
 
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
@@ -63,14 +82,9 @@ impl Specify for ItemStruct {
 impl Specify for ItemEnum {
     type Spec = DataSpec;
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = Parser::parse2(DataSpec::parse, input)?;
-        Ok(SpecItem { spec, item: self })
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
     }
-}
-
-impl Specify for ItemTrait {
-    type Spec = DataSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
@@ -81,13 +95,30 @@ impl Specify for ItemTrait {
 impl Specify for ItemImpl {
     type Spec = DataSpec;
 
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
 
-impl<Item: Parse + HasAttrs + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
+impl Specify for ItemTrait {
+    type Spec = DataSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = Parser::parse2(DataSpec::parse, input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl<Item: Parse + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: Item = input.parse()?;
         let Some(attr) = remove_spec_attr(item.get_attrs_mut())? else {
@@ -98,52 +129,6 @@ impl<Item: Parse + HasAttrs + Spanned + Specify> Parse for SpecItem<Item::Spec, 
         };
         let spec_input = get_attr_input(attr)?;
         item.parse_spec(spec_input)
-    }
-}
-
-trait HasAttrs {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
-}
-
-impl HasAttrs for ItemFn {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for ImplItemFn {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for TraitItemFn {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for ItemStruct {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for ItemEnum {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for ItemTrait {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
-    }
-}
-
-impl HasAttrs for ItemImpl {
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        &mut self.attrs
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -154,8 +154,7 @@ pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>>
 }
 
 fn path_matches_name(path: &Path, name: &str) -> bool {
-    path.get_ident()
-        .is_some_and(|ident| *ident == name)
+    path.get_ident().is_some_and(|ident| *ident == name)
 }
 
 pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta,
     Path, TraitItemFn,
-    parse::{Parse, ParseStream, Result},
+    parse::{Parse, ParseStream, Parser, Result},
     parse_quote,
     spanned::Spanned,
 };
@@ -28,7 +28,7 @@ impl Specify for ItemFn {
     type Spec = FnSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = syn::parse2(input)?;
+        let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -37,7 +37,7 @@ impl Specify for ImplItemFn {
     type Spec = FnSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = syn::parse2(input)?;
+        let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -46,7 +46,7 @@ impl Specify for TraitItemFn {
     type Spec = FnSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = syn::parse2(input)?;
+        let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -55,7 +55,7 @@ impl Specify for ItemStruct {
     type Spec = DataSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = syn::parse2(input)?;
+        let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -64,7 +64,7 @@ impl Specify for ItemEnum {
     type Spec = DataSpec;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
-        let spec = syn::parse2(input)?;
+        let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
 }
@@ -161,8 +161,8 @@ pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
     }
 }
 
-impl Parse for FnSpec {
-    fn parse(input: ParseStream) -> Result<Self> {
+impl FnSpec {
+    fn parse(input: ParseStream) -> Result<FnSpec> {
         let raw_spec = syntax::SpecFields::parse(input)?;
 
         let mut errors = MultiError::empty();
@@ -293,7 +293,7 @@ impl Parse for FnSpec {
     }
 }
 
-impl Parse for DataSpec {
+impl DataSpec {
     fn parse(input: ParseStream) -> Result<Self> {
         let raw_spec = syntax::SpecFields::parse(input)?;
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,9 +1,7 @@
 use proc_macro2::TokenStream;
 use syn::{
-    Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemImpl,
-    ItemStruct, ItemTrait, Meta, Path, TraitItemFn,
-    parse::{Parse, ParseStream, Result},
-    parse_quote,
+    Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, ImplItemFn, ItemEnum,
+    ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, Path, TraitItemFn, parse::Result, parse_quote,
     spanned::Spanned,
 };
 
@@ -125,6 +123,30 @@ impl Specified for ItemImpl {
 
 impl Specified for ItemTrait {
     type Spec = DataSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
+    }
+}
+
+impl Specified for ExprForLoop {
+    type Spec = LoopSpec;
+
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+        fields.try_into()
+    }
+}
+
+impl Specified for ExprWhile {
+    type Spec = LoopSpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
@@ -347,10 +369,11 @@ impl TryFrom<SpecFields> for DataSpec {
     }
 }
 
-impl Parse for LoopSpec {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let raw_spec = syntax::SpecFields::parse(input)?;
+impl TryFrom<SpecFields> for LoopSpec {
+    type Error = Error;
 
+    fn try_from(raw_spec: SpecFields) -> Result<Self> {
+        let span = raw_spec.span();
         let is_sorted = raw_spec.is_sorted();
 
         let mut errors = MultiError::empty();
@@ -387,7 +410,7 @@ impl Parse for LoopSpec {
 
         if !is_sorted {
             errors.add(Error::new(
-                input.span(),
+                span,
                 "fields are out of order: the expected order is `maintains`, `decreases`",
             ));
         }
@@ -399,7 +422,7 @@ impl Parse for LoopSpec {
         Ok(Self {
             maintains,
             decreases,
-            span: input.span(),
+            span,
         })
     }
 }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -69,16 +69,6 @@ impl Specify for ItemEnum {
     }
 }
 
-pub trait ParseOnItem<Item>: Sized {
-    fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self>;
-}
-
-impl<Item: Specify> ParseOnItem<Item> for SpecItem<Item::Spec, Item> {
-    fn parse_spec_on(item: Item, spec_input: TokenStream) -> Result<Self> {
-        item.parse_spec(spec_input)
-    }
-}
-
 impl<Item: Parse + HasAttrs + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: Item = input.parse()?;

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use syn::{
-    Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta,
-    Path, TraitItemFn,
+    Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemImpl,
+    ItemStruct, ItemTrait, Meta, Path, TraitItemFn,
     parse::{Parse, ParseStream, Parser, Result},
     parse_quote,
     spanned::Spanned,
@@ -69,6 +69,24 @@ impl Specify for ItemEnum {
     }
 }
 
+impl Specify for ItemTrait {
+    type Spec = DataSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = Parser::parse2(DataSpec::parse, input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
+impl Specify for ItemImpl {
+    type Spec = DataSpec;
+
+    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+        let spec = Parser::parse2(DataSpec::parse, input)?;
+        Ok(SpecItem { spec, item: self })
+    }
+}
+
 impl<Item: Parse + HasAttrs + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: Item = input.parse()?;
@@ -112,6 +130,18 @@ impl HasAttrs for ItemStruct {
 }
 
 impl HasAttrs for ItemEnum {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+}
+
+impl HasAttrs for ItemTrait {
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
+        &mut self.attrs
+    }
+}
+
+impl HasAttrs for ItemImpl {
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
     }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,13 +1,14 @@
 use syn::{
-    Attribute, Error, Expr, ExprAssign, FieldValue, ItemFn, Meta, Path,
+    Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta,
+    Path, TraitItemFn,
     parse::{Parse, ParseStream, Result},
     parse_quote,
     spanned::Spanned,
 };
 
 use crate::{
-    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecItemFn,
-    qualifiers::FnQualifiers,
+    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecEnumItem,
+    SpecImplItemFn, SpecItemFn, SpecItemStruct, SpecTraitItemFn, qualifiers::FnQualifiers,
 };
 
 pub mod syntax;
@@ -28,6 +29,62 @@ impl Parse for SpecItemFn {
         };
         let spec = attr.meta.try_into()?;
         Ok(SpecItemFn { spec, item })
+    }
+}
+
+impl Parse for SpecImplItemFn {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut item: ImplItemFn = input.parse()?;
+        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
+            return Err(Error::new_spanned(
+                item,
+                "expected a `#[spec]` attribute on this `fn`",
+            ));
+        };
+        let spec = attr.meta.try_into()?;
+        Ok(SpecImplItemFn { spec, item })
+    }
+}
+
+impl Parse for SpecTraitItemFn {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut item: TraitItemFn = input.parse()?;
+        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
+            return Err(Error::new_spanned(
+                item,
+                "expected a `#[spec]` attribute on this `fn`",
+            ));
+        };
+        let spec = attr.meta.try_into()?;
+        Ok(SpecTraitItemFn { spec, item })
+    }
+}
+
+impl Parse for SpecItemStruct {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut item: ItemStruct = input.parse()?;
+        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
+            return Err(Error::new_spanned(
+                item,
+                "expected a `#[spec]` attribute on this `struct`",
+            ));
+        };
+        let spec = attr.meta.try_into()?;
+        Ok(SpecItemStruct { spec, item })
+    }
+}
+
+impl Parse for SpecEnumItem {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut item: ItemEnum = input.parse()?;
+        let Some(attr) = remove_spec_attr(&mut item.attrs)? else {
+            return Err(Error::new_spanned(
+                item,
+                "expected a `#[spec]` attribute on this `enum`",
+            ));
+        };
+        let spec = attr.meta.try_into()?;
+        Ok(SpecEnumItem { spec, item })
     }
 }
 
@@ -71,6 +128,21 @@ impl TryFrom<Meta> for Spec {
     fn try_from(meta: Meta) -> Result<Self> {
         match meta {
             Meta::Path(_) => Ok(Spec::empty()),
+            Meta::List(list) => syn::parse2(list.tokens),
+            Meta::NameValue(key_value) => Err(Error::new_spanned(
+                key_value.eq_token,
+                "expected arguments between delimiters `()`, `[]`, or `{}`",
+            )),
+        }
+    }
+}
+
+impl TryFrom<Meta> for DataSpec {
+    type Error = Error;
+
+    fn try_from(meta: Meta) -> Result<Self> {
+        match meta {
+            Meta::Path(_) => Ok(DataSpec::empty()),
             Meta::List(list) => syn::parse2(list.tokens),
             Meta::NameValue(key_value) => Err(Error::new_spanned(
                 key_value.eq_token,

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,7 +8,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, LoopSpec, LoopVariant, PostCondition, Spec, SpecImplItemFn,
+    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition, SpecImplItemFn,
     SpecItemEnum, SpecItemFn, SpecItemStruct, SpecTraitItemFn, qualifiers::FnQualifiers,
 };
 
@@ -168,7 +168,7 @@ pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
     }
 }
 
-impl Parse for Spec {
+impl Parse for FnSpec {
     fn parse(input: ParseStream) -> Result<Self> {
         let raw_spec = syntax::SpecFields::parse(input)?;
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -27,10 +27,10 @@ pub trait Specified: Sized {
     /// Parse the `#[spec]` from the `Attribute` list.
     ///
     /// - If the AST node has a `#[spec]` attribute, it is removed from the `Attribute` list,
-    ///     and its contents are parsed as `Self::Spec`, then attached to the AST node.
+    ///   and its contents are parsed as `Self::Spec`, then attached to the AST node.
     /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
     /// - Multiple `#[spec]` attributes are not allowed and cause an error.
-    fn with_spec_from_attrs(&mut self) -> Result<Self::Spec>
+    fn parse_spec_from_attrs(&mut self) -> Result<Self::Spec>
     where
         Self: Spanned,
     {
@@ -40,13 +40,13 @@ pub trait Specified: Sized {
             TokenStream::new()
         };
         let spec_fields: SpecFields = syn::parse2(spec_input)?;
-        self.with_spec_from_fields(spec_fields)
+        self.parse_spec_from_fields(spec_fields)
     }
 
     /// Parse the `#[spec]` from `SpecFields`.
     ///
     /// Implement this to parse a spec in the context of its AST node.
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec>;
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec>;
 
     /// Get a mutable reference to the `Attribute` list.
     ///
@@ -57,7 +57,7 @@ pub trait Specified: Sized {
 impl<AstNode: Parse + Spanned + Specified> Parse for NodeWithSpec<AstNode::Spec, AstNode> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut node: AstNode = input.parse()?;
-        let spec = node.with_spec_from_attrs()?;
+        let spec = node.parse_spec_from_attrs()?;
         Ok(Self { spec, node })
     }
 }
@@ -69,7 +69,7 @@ impl Specified for ItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -81,7 +81,7 @@ impl Specified for ImplItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -93,7 +93,7 @@ impl Specified for TraitItemFn {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -105,7 +105,7 @@ impl Specified for ItemStruct {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -117,7 +117,7 @@ impl Specified for ItemEnum {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -129,7 +129,7 @@ impl Specified for ItemImpl {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }
@@ -141,7 +141,7 @@ impl Specified for ItemTrait {
         &mut self.attrs
     }
 
-    fn with_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
+    fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
         fields.try_into()
     }
 }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -19,14 +19,18 @@ use syntax::Keyword;
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
 
+/// Implemented by AST node types that may have a `#[spec]` attribute.
 pub trait Specify: Sized {
+    /// The type of the spec associated with this AST node type.
     type Spec;
 
-    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
-
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
-
-    fn parse_spec_attr(mut self) -> Result<SpecItem<Self::Spec, Self>>
+    /// Attach the `#[spec]` from the `Attribute` list.
+    ///
+    /// - If the AST node has a `#[spec]` attribute, it is removed from the `Attribute` list,
+    ///     and its contents are parsed as `Self::Spec`, then attached to the AST node.
+    /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
+    /// - Multiple `#[spec]` attributes are not allowed and cause an error.
+    fn with_spec_attr(mut self) -> Result<SpecItem<Self::Spec, Self>>
     where
         Self: Spanned,
     {
@@ -35,14 +39,20 @@ pub trait Specify: Sized {
         } else {
             TokenStream::new()
         };
-        self.parse_spec(spec_input)
+        self.with_spec_parse(spec_input)
     }
+
+    /// Attach the `#[spec]` by parsing it from a `TokenStream`.
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
+
+    /// Get a mutable reference to the `Attribute` list.
+    fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
 }
 
 impl<Item: Parse + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
     fn parse(input: ParseStream) -> Result<Self> {
         let item: Item = input.parse()?;
-        item.parse_spec_attr()
+        item.with_spec_attr()
     }
 }
 
@@ -53,7 +63,7 @@ impl Specify for ItemFn {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -66,7 +76,7 @@ impl Specify for ImplItemFn {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -79,7 +89,7 @@ impl Specify for TraitItemFn {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(FnSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -92,7 +102,7 @@ impl Specify for ItemStruct {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -105,7 +115,7 @@ impl Specify for ItemEnum {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -118,7 +128,7 @@ impl Specify for ItemImpl {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }
@@ -131,7 +141,7 @@ impl Specify for ItemTrait {
         &mut self.attrs
     }
 
-    fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
+    fn with_spec_parse(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
     }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -158,7 +158,7 @@ fn path_matches_name(path: &Path, name: &str) -> bool {
         .is_some_and(|ident| ident.to_string() == name)
 }
 
-fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
+pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
     match attr.meta {
         Meta::Path(_) => Ok(TokenStream::new()),
         Meta::List(list) => Ok(list.tokens),

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -30,13 +30,11 @@ pub trait Specify: Sized {
     where
         Self: Spanned,
     {
-        let Some(attr) = remove_spec_attr(self.get_attrs_mut())? else {
-            return Err(Error::new(
-                self.span(),
-                "expected a `#[spec]` attribute on this item",
-            ));
+        let spec_input = if let Some(attr) = remove_spec_attr(self.get_attrs_mut())? {
+            get_attr_input(attr)?
+        } else {
+            TokenStream::new()
         };
-        let spec_input = get_attr_input(attr)?;
         self.parse_spec(spec_input)
     }
 }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,3 +1,4 @@
+use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, ExprAssign, FieldValue, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta,
     Path, TraitItemFn,
@@ -18,6 +19,13 @@ use syntax::Keyword;
 #[path = "annotate_tests.rs"]
 mod annotate_tests;
 
+impl SpecItemFn {
+    pub fn parse_spec_on(item: ItemFn, spec_input: TokenStream) -> Result<Self> {
+        let spec = syn::parse2(spec_input)?;
+        Ok(SpecItemFn { spec, item })
+    }
+}
+
 impl Parse for SpecItemFn {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut item: ItemFn = input.parse()?;
@@ -27,8 +35,15 @@ impl Parse for SpecItemFn {
                 "expected a `#[spec]` attribute on this `fn`",
             ));
         };
-        let spec = attr.meta.try_into()?;
-        Ok(SpecItemFn { spec, item })
+        let spec_input = get_attr_input(attr)?;
+        Self::parse_spec_on(item, spec_input)
+    }
+}
+
+impl SpecImplItemFn {
+    pub fn parse_spec_on(item: ImplItemFn, spec_input: TokenStream) -> Result<Self> {
+        let spec = syn::parse2(spec_input)?;
+        Ok(SpecImplItemFn { spec, item })
     }
 }
 
@@ -41,8 +56,15 @@ impl Parse for SpecImplItemFn {
                 "expected a `#[spec]` attribute on this `fn`",
             ));
         };
-        let spec = attr.meta.try_into()?;
-        Ok(SpecImplItemFn { spec, item })
+        let spec_input = get_attr_input(attr)?;
+        Self::parse_spec_on(item, spec_input)
+    }
+}
+
+impl SpecTraitItemFn {
+    pub fn parse_spec_on(item: TraitItemFn, spec_input: TokenStream) -> Result<Self> {
+        let spec = syn::parse2(spec_input)?;
+        Ok(SpecTraitItemFn { spec, item })
     }
 }
 
@@ -55,8 +77,15 @@ impl Parse for SpecTraitItemFn {
                 "expected a `#[spec]` attribute on this `fn`",
             ));
         };
-        let spec = attr.meta.try_into()?;
-        Ok(SpecTraitItemFn { spec, item })
+        let spec_input = get_attr_input(attr)?;
+        Self::parse_spec_on(item, spec_input)
+    }
+}
+
+impl SpecItemStruct {
+    pub fn parse_spec_on(item: ItemStruct, spec_input: TokenStream) -> Result<Self> {
+        let spec = syn::parse2(spec_input)?;
+        Ok(SpecItemStruct { spec, item })
     }
 }
 
@@ -69,8 +98,15 @@ impl Parse for SpecItemStruct {
                 "expected a `#[spec]` attribute on this `struct`",
             ));
         };
-        let spec = attr.meta.try_into()?;
-        Ok(SpecItemStruct { spec, item })
+        let spec_input = get_attr_input(attr)?;
+        Self::parse_spec_on(item, spec_input)
+    }
+}
+
+impl SpecEnumItem {
+    pub fn parse_spec_on(item: ItemEnum, spec_input: TokenStream) -> Result<Self> {
+        let spec = syn::parse2(spec_input)?;
+        Ok(SpecEnumItem { spec, item })
     }
 }
 
@@ -83,8 +119,8 @@ impl Parse for SpecEnumItem {
                 "expected a `#[spec]` attribute on this `enum`",
             ));
         };
-        let spec = attr.meta.try_into()?;
-        Ok(SpecEnumItem { spec, item })
+        let spec_input = get_attr_input(attr)?;
+        Self::parse_spec_on(item, spec_input)
     }
 }
 
@@ -122,33 +158,14 @@ fn path_matches_name(path: &Path, name: &str) -> bool {
         .is_some_and(|ident| ident.to_string() == name)
 }
 
-impl TryFrom<Meta> for Spec {
-    type Error = Error;
-
-    fn try_from(meta: Meta) -> Result<Self> {
-        match meta {
-            Meta::Path(_) => Ok(Spec::empty()),
-            Meta::List(list) => syn::parse2(list.tokens),
-            Meta::NameValue(key_value) => Err(Error::new_spanned(
-                key_value.eq_token,
-                "expected arguments between delimiters `()`, `[]`, or `{}`",
-            )),
-        }
-    }
-}
-
-impl TryFrom<Meta> for DataSpec {
-    type Error = Error;
-
-    fn try_from(meta: Meta) -> Result<Self> {
-        match meta {
-            Meta::Path(_) => Ok(DataSpec::empty()),
-            Meta::List(list) => syn::parse2(list.tokens),
-            Meta::NameValue(key_value) => Err(Error::new_spanned(
-                key_value.eq_token,
-                "expected arguments between delimiters `()`, `[]`, or `{}`",
-            )),
-        }
+fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
+    match attr.meta {
+        Meta::Path(_) => Ok(TokenStream::new()),
+        Meta::List(list) => Ok(list.tokens),
+        Meta::NameValue(key_value) => Err(Error::new_spanned(
+            key_value.eq_token,
+            "expected arguments between delimiters `()`, `[]`, or `{}`",
+        )),
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,7 +8,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, NodeWithSpec, PostCondition,
+    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
     annotate::syntax::SpecFields, qualifiers::FnQualifiers,
 };
 
@@ -20,7 +20,7 @@ use syntax::Keyword;
 mod annotate_tests;
 
 /// Implemented by AST nodes that may have a `#[spec]` attribute.
-pub trait Specified: Sized {
+pub trait Specified {
     /// The spec type associated with this AST node.
     type Spec;
 
@@ -30,10 +30,7 @@ pub trait Specified: Sized {
     ///   and its contents are parsed as `Self::Spec`, then attached to the AST node.
     /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
     /// - Multiple `#[spec]` attributes are not allowed and cause an error.
-    fn parse_spec_from_attrs(&mut self) -> Result<Self::Spec>
-    where
-        Self: Spanned,
-    {
+    fn parse_spec_from_attrs(&mut self) -> Result<Self::Spec> {
         let spec_input: TokenStream = if let Some(attr) = remove_spec_attr(self.get_attrs_mut())? {
             get_attr_input(attr)?
         } else {
@@ -52,14 +49,6 @@ pub trait Specified: Sized {
     ///
     /// Needed to by the default `with_spec_from_attrs`.
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
-}
-
-impl<AstNode: Parse + Spanned + Specified> Parse for NodeWithSpec<AstNode::Spec, AstNode> {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut node: AstNode = input.parse()?;
-        let spec = node.parse_spec_from_attrs()?;
-        Ok(Self { spec, node })
-    }
 }
 
 impl Specified for ItemFn {

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -25,6 +25,27 @@ pub trait Specify: Sized {
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute>;
 
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>>;
+
+    fn parse_spec_attr(mut self) -> Result<SpecItem<Self::Spec, Self>>
+    where
+        Self: Spanned,
+    {
+        let Some(attr) = remove_spec_attr(self.get_attrs_mut())? else {
+            return Err(Error::new(
+                self.span(),
+                "expected a `#[spec]` attribute on this item",
+            ));
+        };
+        let spec_input = get_attr_input(attr)?;
+        self.parse_spec(spec_input)
+    }
+}
+
+impl<Item: Parse + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let item: Item = input.parse()?;
+        item.parse_spec_attr()
+    }
 }
 
 impl Specify for ItemFn {
@@ -115,20 +136,6 @@ impl Specify for ItemTrait {
     fn parse_spec(self, input: TokenStream) -> Result<SpecItem<Self::Spec, Self>> {
         let spec = Parser::parse2(DataSpec::parse, input)?;
         Ok(SpecItem { spec, item: self })
-    }
-}
-
-impl<Item: Parse + Spanned + Specify> Parse for SpecItem<Item::Spec, Item> {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let mut item: Item = input.parse()?;
-        let Some(attr) = remove_spec_attr(item.get_attrs_mut())? else {
-            return Err(Error::new(
-                item.span(),
-                "expected a `#[spec]` attribute on this item",
-            ));
-        };
-        let spec_input = get_attr_input(attr)?;
-        item.parse_spec(spec_input)
     }
 }
 

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,3 +1,4 @@
+use quote::ToTokens;
 use syn::{
     FieldValue, Ident, Member, Token,
     parse::{Parse, ParseStream, Result},
@@ -14,6 +15,12 @@ use syn::{
 #[derive(Debug, Clone)]
 pub struct SpecFields {
     pub fields: Punctuated<FieldValue, Token![,]>,
+}
+
+impl ToTokens for SpecFields {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.fields.to_tokens(tokens);
+    }
 }
 
 impl Parse for SpecFields {

--- a/crates/anodized-core/src/annotate/syntax.rs
+++ b/crates/anodized-core/src/annotate/syntax.rs
@@ -1,6 +1,7 @@
+use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
-    FieldValue, Ident, Member, Token,
+    Attribute, Error, FieldValue, Ident, Member, Meta, Path, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
 };
@@ -105,5 +106,53 @@ impl std::fmt::Display for Keyword {
             Keyword::Ensures => write!(f, "ensures"),
             Keyword::Decreases => write!(f, "decreases"),
         }
+    }
+}
+
+/// Removes a single `#[spec]` attribute, if present, from an attribute list.
+///
+/// If there are multiple `#[spec]` attributes, returns `Err`.
+/// The arguments of the `#[spec]` attribute are *not* validated.
+pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
+    let mut maybe_index = None;
+
+    for (i, attr) in attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
+    {
+        if maybe_index.is_some() {
+            return Err(Error::new_spanned(
+                attr,
+                "multiple `#[spec]` attributes are not allowed",
+            ));
+        }
+        maybe_index = Some(i);
+    }
+
+    if let Some(index) = maybe_index {
+        let attr = attrs.remove(index);
+        Ok(Some(attr))
+    } else {
+        Ok(None)
+    }
+}
+
+fn path_matches_name(path: &Path, name: &str) -> bool {
+    path.get_ident().is_some_and(|ident| *ident == name)
+}
+
+/// Get the `TokenStream` that represents the arguments of an `Attribute`.
+///
+/// - If the attribute has no arguments, returns an empty stream.
+/// - If the attribute has a `key = value` style argument, returns an error.
+pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
+    match attr.meta {
+        Meta::Path(_) => Ok(TokenStream::new()),
+        Meta::List(list) => Ok(list.tokens),
+        Meta::NameValue(key_value) => Err(Error::new_spanned(
+            key_value.eq_token,
+            "expected arguments between delimiters `()`, `[]`, or `{}`",
+        )),
     }
 }

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1,4 +1,4 @@
-use crate::test_util::assert_spec_eq;
+use crate::{SpecItemFn, test_util::assert_spec_eq};
 
 use super::*;
 use proc_macro2::Span;

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -7,9 +7,12 @@ use syn::{parse_quote, parse_str};
 
 #[test]
 fn simple_spec() {
-    let spec: Spec = parse_quote! {
-        requires: is_valid(x),
-        ensures: output > x,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: is_valid(x),
+            ensures: output > x,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -28,13 +31,14 @@ fn simple_spec() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn fn_qualifiers_functional() {
-    let spec: Spec = parse_quote! {
-        functional
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(functional)]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -46,14 +50,14 @@ fn fn_qualifiers_functional() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn fn_qualifiers_pure_total() {
-    let spec: Spec = parse_quote! {
-        pure,
-        total,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(pure, total)]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -65,16 +69,19 @@ fn fn_qualifiers_pure_total() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
-    let spec: Spec = parse_quote! {
-        deterministic,
-        effectfree,
-        infallible,
-        terminating,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            deterministic,
+            effectfree,
+            infallible,
+            terminating,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -89,101 +96,111 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 #[should_panic = "expected `,`"]
 fn fn_qualifiers_typo_missing_comma() {
-    let _: Spec = parse_quote! {
-        pure total,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(pure total)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "qualifier does not take a value"]
 fn fn_qualifiers_typo_colon_instead_of_comma() {
-    let _: Spec = parse_quote! {
-        pure: total,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(pure: total)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "expected an expression"]
 fn fn_qualifiers_invalid_colon() {
-    let _: Spec = parse_quote! {
-        pure:,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(pure:)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "qualifier does not take a value"]
 fn fn_qualifiers_invalid_value_expr() {
-    let _: Spec = parse_quote! {
-        functional: x == 42,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(functional: x == 42)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_functional_pure() {
-    let _: Spec = parse_quote! {
-        functional,
-        pure,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(functional, pure)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_functional_total() {
-    let _: Spec = parse_quote! {
-        functional,
-        total,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(functional, total)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_pure_deterministic() {
-    let _: Spec = parse_quote! {
-        pure,
-        deterministic,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            pure,
+            deterministic,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_pure_effectfree() {
-    let _: Spec = parse_quote! {
-        pure,
-        effectfree,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(pure, effectfree)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_total_infallible() {
-    let _: Spec = parse_quote! {
-        total,
-        infallible,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(total, infallible)]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic = "this qualifier is redundant; remove it"]
 fn fn_qualifiers_total_terminating() {
-    let _: Spec = parse_quote! {
-        total,
-        terminating,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(total, terminating)]
+        fn f() {}
     };
 }
 
 #[test]
 fn all_clauses() {
-    let spec: Spec = parse_quote! {
-        requires: x > 0 && x.is_power_of_two(),
-        maintains: self.is_valid(),
-        ensures: |z| z >= x,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: x > 0 && x.is_power_of_two(),
+            maintains: self.is_valid(),
+            ensures: |z| z >= x,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -205,34 +222,43 @@ fn all_clauses() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 #[should_panic(expected = "unknown spec field")]
 fn unknown_keyword() {
-    let _: Spec = parse_quote! {
-        ensures: output == x,
-        goat: 42,
-        requires: x > 0 && !is_zero(x),
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            ensures: output == x,
+            goat: 42,
+            requires: x > 0 && !is_zero(x),
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic(expected = "fields are out of order")]
 fn out_of_order() {
-    let _: Spec = parse_quote! {
-        ensures: output == x,
-        requires: x > 0 && !is_zero(x),
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            ensures: output == x,
+            requires: x > 0 && !is_zero(x),
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic(expected = "no longer supported")]
 fn multiple_binds() {
-    let _: Spec = parse_quote! {
-        inspects: y,
-        inspects: z,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            inspects: y,
+            inspects: z,
+        )]
+        fn f() {}
     };
 }
 
@@ -241,23 +267,29 @@ fn multiple_binds() {
     expected = "at most one `captures` field is allowed; to capture multiple values, use a list"
 )]
 fn multiple_captures() {
-    let _: Spec = parse_quote! {
-        captures: old_value = value,
-        captures: old_count = count,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: old_value = value,
+            captures: old_count = count,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 fn array_of_conditions() {
-    let spec: Spec = parse_quote! {
-        requires: [
-            x >= 0,
-            y.len() < 10,
-        ],
-        ensures: [
-            output != x,
-            |retval| retval.is_some(),
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: [
+                x >= 0,
+                y.len() < 10,
+            ],
+            ensures: [
+                output != x,
+                |retval| retval.is_some(),
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -289,13 +321,16 @@ fn array_of_conditions() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn ensures_with_explicit_closure() {
-    let spec: Spec = parse_quote! {
-        ensures: |result| result.is_ok() || result.unwrap_err().kind() == ErrorKind::NotFound,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            ensures: |result| result.is_ok() || result.unwrap_err().kind() == ErrorKind::NotFound,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -311,16 +346,19 @@ fn ensures_with_explicit_closure() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn multiple_clauses_of_same_flavor() {
-    let spec: Spec = parse_quote! {
-        requires: x > 0 || x < -10,
-        requires: y.is_ascii(),
-        ensures: retval < x,
-        ensures: |output| output.len() >= y.len(),
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: x > 0 || x < -10,
+            requires: y.is_ascii(),
+            ensures: retval < x,
+            ensures: |output| output.len() >= y.len(),
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -352,26 +390,29 @@ fn multiple_clauses_of_same_flavor() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn mixed_single_and_array_clauses() {
-    let spec: Spec = parse_quote! {
-        requires: x == 0,
-        requires: [
-            y > 1,
-            z.is_empty() || z.contains("foo"),
-        ],
-        ensures: [
-            output != y,
-            |val| output.starts_with(z),
-        ],
-        ensures: retval.len() > x,
-        ensures: |output| [
-            output >= x,
-            x != z,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: x == 0,
+            requires: [
+                y > 1,
+                z.is_empty() || z.contains("foo"),
+            ],
+            ensures: [
+                output != y,
+                |val| output.starts_with(z),
+            ],
+            ensures: retval.len() > x,
+            ensures: |output| [
+                output >= x,
+                x != z,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -422,16 +463,19 @@ fn mixed_single_and_array_clauses() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn cfg_attributes() {
-    let spec: Spec = parse_quote! {
-        #[cfg(test)]
-        requires: x > 0 && is_mode(),
-        #[cfg(not(debug_assertions))]
-        ensures: output < x,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(test)]
+            requires: x > 0 && is_mode(),
+            #[cfg(not(debug_assertions))]
+            ensures: output < x,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -450,43 +494,55 @@ fn cfg_attributes() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 #[should_panic(expected = "unsupported attribute; only `cfg` is allowed")]
 fn non_cfg_attribute() {
-    let _: Spec = parse_quote! {
-        #[allow(dead_code)]
-        requires: x > 0,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            #[allow(dead_code)]
+            requires: x > 0,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic(expected = "multiple `cfg` attributes are not supported")]
 fn multiple_cfg_attributes() {
-    let _: Spec = parse_quote! {
-        #[cfg(test)]
-        #[cfg(debug_assertions)]
-        requires: x > 0,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(test)]
+            #[cfg(debug_assertions)]
+            requires: x > 0,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 #[should_panic(expected = "no longer supported")]
 fn cfg_on_binds() {
-    let _: Spec = parse_quote! {
-        #[cfg(test)]
-        inspects: y,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(test)]
+            inspects: y,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 fn macro_in_condition() {
-    let spec: Spec = parse_quote! {
-        requires: matches!(self.state, State::Idle),
-        maintains: matches!(self.state, State::Idle | State::Running | State::Finished),
-        ensures: matches!(self.state, State::Running),
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: matches!(self.state, State::Idle),
+            maintains: matches!(self.state, State::Idle | State::Running | State::Finished),
+            ensures: matches!(self.state, State::Running),
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -508,16 +564,19 @@ fn macro_in_condition() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn binds_pattern() {
-    let spec: Spec = parse_quote! {
-        ensures: |(a, b)| [
-            a <= b,
-            (a, b) == pair || (b, a) == pair,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            ensures: |(a, b)| [
+                a <= b,
+                (a, b) == pair || (b, a) == pair,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -540,18 +599,21 @@ fn binds_pattern() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn multiple_conditions() {
-    let spec: Spec = parse_quote! {
-        requires: [
-            self.initialized,
-            !self.locked,
-        ],
-        requires: index < self.items.len(),
-        maintains: self.items.len() <= self.items.capacity(),
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: [
+                self.initialized,
+                !self.locked,
+            ],
+            requires: index < self.items.len(),
+            maintains: self.items.len() <= self.items.capacity(),
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -579,16 +641,19 @@ fn multiple_conditions() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn rename_return_value() {
-    let spec: Spec = parse_quote! {
-        ensures: |result| [
-            result > output,
-            result % 2 == 0,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            ensures: |result| [
+                result > output,
+                result % 2 == 0,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -611,14 +676,17 @@ fn rename_return_value() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_simple_identifier() {
-    let spec: Spec = parse_quote! {
-        captures: old_count = count,
-        ensures: output == old_count + 1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: old_count = count,
+            ensures: output == old_count + 1,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -637,14 +705,17 @@ fn captures_simple_identifier() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_identifier_with_alias() {
-    let spec: Spec = parse_quote! {
-        captures: prev_value = value,
-        ensures: output > prev_value,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: prev_value = value,
+            ensures: output > prev_value,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -663,22 +734,25 @@ fn captures_identifier_with_alias() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_array() {
-    let spec: Spec = parse_quote! {
-        captures: [
-            old_count = count,
-            old_index = index,
-            old_value = value,
-        ],
-        ensures: [
-            count == old_count + 1,
-            index == old_index + 1,
-            value > old_value,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: [
+                old_count = count,
+                old_index = index,
+                old_value = value,
+            ],
+            ensures: [
+                count == old_count + 1,
+                index == old_index + 1,
+                value > old_value,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -719,16 +793,19 @@ fn captures_array() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_with_all_clauses() {
-    let spec: Spec = parse_quote! {
-        requires: x > 0,
-        maintains: self.is_valid(),
-        captures: old_val = value,
-        ensures: |result| result > old_val,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: x > 0,
+            maintains: self.is_valid(),
+            captures: old_val = value,
+            ensures: |result| result > old_val,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -753,23 +830,29 @@ fn captures_with_all_clauses() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 #[should_panic(expected = "fields are out of order")]
 fn captures_out_of_order() {
-    let _: Spec = parse_quote! {
-        captures: old_value = value,
-        maintains: self.is_valid(),
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: old_value = value,
+            maintains: self.is_valid(),
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 fn captures_array_expression() {
-    let spec: Spec = parse_quote! {
-        captures: slice = [a, b, c],
-        ensures: slice.len() == 3,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: slice = [a, b, c],
+            ensures: slice.len() == 3,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -788,38 +871,47 @@ fn captures_array_expression() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_complex_expressions() {
-    let spec: Spec = parse_quote! {
-        captures: [
-            item_count = self.items.len(),
-            bar = foo.bar(),
-            sum = a + b,
-            first = foo[0],
-        ],
-        ensures: output > 0,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: [
+                item_count = self.items.len(),
+                bar = foo.bar(),
+                sum = a + b,
+                first = foo[0],
+            ],
+            ensures: output > 0,
+        )]
+        fn f() {}
     };
 
-    assert_eq!(spec.captures.len(), 4);
+    assert_eq!(spec_item_fn.spec.captures.len(), 4);
 }
 
 #[test]
 #[should_panic(expected = "`cfg` attribute is not supported here")]
 fn cfg_on_captures() {
-    let _: Spec = parse_quote! {
-        #[cfg(test)]
-        captures: old_value = value,
-        ensures: output > old_value,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(test)]
+            captures: old_value = value,
+            ensures: output > old_value,
+        )]
+        fn f() {}
     };
 }
 
 #[test]
 fn captures_edge_case_cast_expr() {
-    let spec: Spec = parse_quote! {
-        captures: old_red = r as u8,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: old_red = r as u8,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -834,17 +926,20 @@ fn captures_edge_case_cast_expr() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_edge_case_array_of_cast_exprs() {
-    let spec: Spec = parse_quote! {
-        captures: r8g8b8 = [
-            r as u8,
-            g as u8,
-            b as u8,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: r8g8b8 = [
+                r as u8,
+                g as u8,
+                b as u8,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -865,17 +960,20 @@ fn captures_edge_case_array_of_cast_exprs() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_edge_case_list_of_cast_exprs() {
-    let spec: Spec = parse_quote! {
-        captures: [
-            old_red = r as u8,
-            old_green = g as u8,
-            old_blue = b as u8,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: [
+                old_red = r as u8,
+                old_green = g as u8,
+                old_blue = b as u8,
+            ],
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -900,13 +998,16 @@ fn captures_edge_case_list_of_cast_exprs() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_pattern_matches_slices() {
-    let spec: Spec = parse_quote! {
-        captures: [r, g, b] = rgb,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: [r, g, b] = rgb,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -921,13 +1022,16 @@ fn captures_pattern_matches_slices() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_pattern_matches_tuples() {
-    let spec: Spec = parse_quote! {
-        captures: (x, y, z) = point,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: (x, y, z) = point,
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -942,13 +1046,16 @@ fn captures_pattern_matches_tuples() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_pattern_matches_structs() {
-    let spec: Spec = parse_quote! {
-        captures: Person { name, age } = person.clone(),
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: Person { name, age } = person.clone(),
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -963,13 +1070,16 @@ fn captures_pattern_matches_structs() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 fn captures_pattern_matches_nested() {
-    let spec: Spec = parse_quote! {
-        captures: Some((a, b)) = data.as_ref(),
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: Some((a, b)) = data.as_ref(),
+        )]
+        fn f() {}
     };
 
     let expected = Spec {
@@ -984,14 +1094,17 @@ fn captures_pattern_matches_nested() {
         span: Span::call_site(),
     };
 
-    assert_spec_eq(&spec, &expected);
+    assert_spec_eq(&spec_item_fn.spec, &expected);
 }
 
 #[test]
 #[should_panic(expected = "expected `,`")]
 fn captures_pattern_with_binding_modifier() {
-    let _: Spec = parse_quote! {
-        captures: Some(inner_tuple @ (a, b)) = data,
+    let _: SpecItemFn = parse_quote! {
+        #[spec(
+            captures: Some(inner_tuple @ (a, b)) = data,
+        )]
+        fn f() {}
     };
 }
 
@@ -1005,19 +1118,28 @@ fn captures_missing_assignment_value_is_rejected_by_spec_fields() {
 #[test]
 #[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_errors_as_spec() {
-    let _: Spec = parse_str("captures: Person { name, age } =,").unwrap();
+    let _: SpecItemFn = parse_quote! {
+        #[spec(captures: Person { name, age } =,)]
+        fn f() {}
+    };
 }
 
 #[test]
 #[should_panic(expected = "expected an assignment or block")]
 fn captures_require_an_assignment() {
-    let _: Spec = parse_str("captures: value,").unwrap();
+    let _: SpecItemFn = parse_quote! {
+        #[spec(captures: value)]
+        fn f() {}
+    };
 }
 
 #[test]
 #[should_panic(expected = "expected `,`")]
 fn captures_with_extra_semicolon() {
-    let _: Spec = parse_str("captures: old_value = value;,").unwrap();
+    let _: SpecItemFn = parse_quote! {
+        #[spec(captures: old_value = value;,)]
+        fn f() {}
+    };
 }
 
 #[test]

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -908,9 +908,7 @@ fn cfg_on_captures() {
 #[test]
 fn captures_edge_case_cast_expr() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: old_red = r as u8,
-        )]
+        #[spec(captures: old_red = r as u8)]
         fn f() {}
     };
 
@@ -932,13 +930,11 @@ fn captures_edge_case_cast_expr() {
 #[test]
 fn captures_edge_case_array_of_cast_exprs() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: r8g8b8 = [
-                r as u8,
-                g as u8,
-                b as u8,
-            ],
-        )]
+        #[spec(captures: r8g8b8 = [
+            r as u8,
+            g as u8,
+            b as u8,
+        ])]
         fn f() {}
     };
 
@@ -1004,9 +1000,7 @@ fn captures_edge_case_list_of_cast_exprs() {
 #[test]
 fn captures_pattern_matches_slices() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: [r, g, b] = rgb,
-        )]
+        #[spec(captures: [r, g, b] = rgb)]
         fn f() {}
     };
 
@@ -1028,9 +1022,7 @@ fn captures_pattern_matches_slices() {
 #[test]
 fn captures_pattern_matches_tuples() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: (x, y, z) = point,
-        )]
+        #[spec(captures: (x, y, z) = point)]
         fn f() {}
     };
 
@@ -1052,9 +1044,7 @@ fn captures_pattern_matches_tuples() {
 #[test]
 fn captures_pattern_matches_structs() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: Person { name, age } = person.clone(),
-        )]
+        #[spec(captures: Person { name, age } = person.clone())]
         fn f() {}
     };
 
@@ -1076,9 +1066,7 @@ fn captures_pattern_matches_structs() {
 #[test]
 fn captures_pattern_matches_nested() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: Some((a, b)) = data.as_ref(),
-        )]
+        #[spec(captures: Some((a, b)) = data.as_ref())]
         fn f() {}
     };
 
@@ -1101,9 +1089,7 @@ fn captures_pattern_matches_nested() {
 #[should_panic(expected = "expected `,`")]
 fn captures_pattern_with_binding_modifier() {
     let _: SpecItemFn = parse_quote! {
-        #[spec(
-            captures: Some(inner_tuple @ (a, b)) = data,
-        )]
+        #[spec(captures: Some(inner_tuple @ (a, b)) = data)]
         fn f() {}
     };
 }

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -15,7 +15,7 @@ fn simple_spec() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![Condition {
             expr: parse_quote! { is_valid(x) },
@@ -41,7 +41,7 @@ fn fn_qualifiers_functional() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::FUNCTIONAL,
         requires: vec![],
         maintains: vec![],
@@ -60,7 +60,7 @@ fn fn_qualifiers_pure_total() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::PURE | FnQualifiers::TOTAL,
         requires: vec![],
         maintains: vec![],
@@ -84,7 +84,7 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::DETERMINISTIC
             | FnQualifiers::EFFECTFREE
             | FnQualifiers::INFALLIBLE
@@ -203,7 +203,7 @@ fn all_clauses() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && x.is_power_of_two() },
@@ -292,7 +292,7 @@ fn array_of_conditions() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
             Condition {
@@ -333,7 +333,7 @@ fn ensures_with_explicit_closure() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -361,7 +361,7 @@ fn multiple_clauses_of_same_flavor() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
             Condition {
@@ -415,7 +415,7 @@ fn mixed_single_and_array_clauses() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
             Condition {
@@ -478,7 +478,7 @@ fn cfg_attributes() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && is_mode() },
@@ -545,7 +545,7 @@ fn macro_in_condition() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle) },
@@ -579,7 +579,7 @@ fn binds_pattern() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -616,7 +616,7 @@ fn multiple_conditions() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![
             Condition {
@@ -656,7 +656,7 @@ fn rename_return_value() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -689,7 +689,7 @@ fn captures_simple_identifier() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -718,7 +718,7 @@ fn captures_identifier_with_alias() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -755,7 +755,7 @@ fn captures_array() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -808,7 +808,7 @@ fn captures_with_all_clauses() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![Condition {
             expr: parse_quote! { x > 0 },
@@ -855,7 +855,7 @@ fn captures_array_expression() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -914,7 +914,7 @@ fn captures_edge_case_cast_expr() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -942,7 +942,7 @@ fn captures_edge_case_array_of_cast_exprs() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -976,7 +976,7 @@ fn captures_edge_case_list_of_cast_exprs() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -1010,7 +1010,7 @@ fn captures_pattern_matches_slices() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -1034,7 +1034,7 @@ fn captures_pattern_matches_tuples() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -1058,7 +1058,7 @@ fn captures_pattern_matches_structs() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],
@@ -1082,7 +1082,7 @@ fn captures_pattern_matches_nested() {
         fn f() {}
     };
 
-    let expected = Spec {
+    let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         requires: vec![],
         maintains: vec![],

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1,4 +1,4 @@
-use crate::{SpecItemFn, test_util::assert_spec_eq};
+use crate::test_util::{SpecItemFn, assert_spec_eq};
 
 use super::*;
 use proc_macro2::Span;

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -256,27 +256,3 @@ request at https://github.com/anodized-rs/anodized/issues/new"#,
     );
     syn::Error::new_spanned(tokens, msg)
 }
-
-/// Finds the `[spec]` attrib in an attribute list.
-///
-/// Returns the spec [Attribute] and the remaining attributes.
-fn find_spec_attr(attrs: Vec<Attribute>) -> syn::Result<(Option<Attribute>, Vec<Attribute>)> {
-    let mut spec_attr = None;
-    let mut other_attrs = Vec::new();
-
-    for attr in attrs {
-        if attr.path().is_ident("spec") {
-            if spec_attr.is_some() {
-                return Err(syn::Error::new_spanned(
-                    attr,
-                    "multiple `#[spec]` attributes on a single item are not supported",
-                ));
-            }
-            spec_attr = Some(attr);
-        } else {
-            other_attrs.push(attr);
-        }
-    }
-
-    Ok((spec_attr, other_attrs))
-}

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -5,7 +5,7 @@ use syn::{
     Signature, parse_quote,
 };
 
-use crate::{DataSpec, Spec};
+use crate::{DataSpec, FnSpec};
 
 pub mod data;
 pub mod fns;
@@ -67,7 +67,7 @@ impl Mode {
         }
     }
 
-    pub fn instrument_item_fn(&self, spec: Spec, mut item_fn: ItemFn) -> Result<TokenStream> {
+    pub fn instrument_item_fn(&self, spec: FnSpec, mut item_fn: ItemFn) -> Result<TokenStream> {
         let mut tokens = TokenStream::new();
 
         if item_fn.sig.ident.to_string().starts_with("__anodized_") {

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -42,7 +42,7 @@ fn embed_spec_item_struct() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_struct(spec_item_struct.spec, spec_item_struct.item)
+        .instrument_item_struct(spec_item_struct.spec, spec_item_struct.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
@@ -89,7 +89,7 @@ fn embed_spec_item_enum() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_enum(spec_item_enum.spec, spec_item_enum.item)
+        .instrument_item_enum(spec_item_enum.spec, spec_item_enum.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -9,7 +9,10 @@ use syn::parse_quote;
 #[test]
 fn embed_spec_item_struct() {
     let spec_item_struct: SpecItemStruct = parse_quote! {
-        #[spec(maintains: [COND_1, COND_2])]
+        #[spec(maintains: [
+            COND_1,
+            COND_2,
+        ])]
         struct STRUCT<'LT_1, TYPE_1: BOUND_1 = DEFAULT_1, const CONST_1: TYPE_2 = DEFAULT_2>
         where
             'LT_1: 'LT_2,
@@ -53,7 +56,10 @@ fn embed_spec_item_struct() {
 #[test]
 fn embed_spec_item_enum() {
     let spec_item_enum: SpecItemEnum = parse_quote! {
-        #[spec(maintains: [COND_1, COND_2])]
+        #[spec(maintains: [
+            COND_1,
+            COND_2,
+        ])]
         enum ENUM<'LT_1, TYPE_1: BOUND_1 = DEFAULT_1, const CONST_1: TYPE_2 = DEFAULT_2>
         where
             'LT_1: 'LT_2,

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -1,17 +1,12 @@
-use crate::{DataSpec, instrument::Mode, test_util::assert_tokens_eq};
+use crate::{SpecEnumItem, SpecItemStruct, instrument::Mode, test_util::assert_tokens_eq};
 
 use proc_macro2::TokenStream;
-use syn::{ItemEnum, ItemStruct, parse_quote};
+use syn::parse_quote;
 
 #[test]
 fn embed_spec_item_struct() {
-    let struct_spec: DataSpec = parse_quote! {
-        maintains: [
-            COND_1,
-            COND_2,
-        ],
-    };
-    let item_struct: ItemStruct = parse_quote! {
+    let spec_item_struct: SpecItemStruct = parse_quote! {
+        #[spec(maintains: [COND_1, COND_2])]
         struct STRUCT<'LT_1, TYPE_1: BOUND_1 = DEFAULT_1, const CONST_1: TYPE_2 = DEFAULT_2>
         where
             'LT_1: 'LT_2,
@@ -47,20 +42,15 @@ fn embed_spec_item_struct() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_struct(struct_spec, item_struct)
+        .instrument_item_struct(spec_item_struct.spec, spec_item_struct.item)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn embed_spec_item_enum() {
-    let struct_spec: DataSpec = parse_quote! {
-        maintains: [
-            COND_1,
-            COND_2,
-        ],
-    };
-    let item_enum: ItemEnum = parse_quote! {
+    let spec_item_enum: SpecEnumItem = parse_quote! {
+        #[spec(maintains: [COND_1, COND_2])]
         enum ENUM<'LT_1, TYPE_1: BOUND_1 = DEFAULT_1, const CONST_1: TYPE_2 = DEFAULT_2>
         where
             'LT_1: 'LT_2,
@@ -99,7 +89,7 @@ fn embed_spec_item_enum() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_enum(struct_spec, item_enum)
+        .instrument_item_enum(spec_item_enum.spec, spec_item_enum.item)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -1,4 +1,4 @@
-use crate::{SpecEnumItem, SpecItemStruct, instrument::Mode, test_util::assert_tokens_eq};
+use crate::{SpecItemEnum, SpecItemStruct, instrument::Mode, test_util::assert_tokens_eq};
 
 use proc_macro2::TokenStream;
 use syn::parse_quote;
@@ -49,7 +49,7 @@ fn embed_spec_item_struct() {
 
 #[test]
 fn embed_spec_item_enum() {
-    let spec_item_enum: SpecEnumItem = parse_quote! {
+    let spec_item_enum: SpecItemEnum = parse_quote! {
         #[spec(maintains: [COND_1, COND_2])]
         enum ENUM<'LT_1, TYPE_1: BOUND_1 = DEFAULT_1, const CONST_1: TYPE_2 = DEFAULT_2>
         where

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -1,4 +1,7 @@
-use crate::{SpecItemEnum, SpecItemStruct, instrument::Mode, test_util::assert_tokens_eq};
+use crate::{
+    instrument::Mode,
+    test_util::{SpecItemEnum, SpecItemStruct, assert_tokens_eq},
+};
 
 use proc_macro2::TokenStream;
 use syn::parse_quote;

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -21,12 +21,7 @@ use crate::{
 };
 
 impl Mode {
-    pub fn instrument_fn(
-        &self,
-        spec: &FnSpec,
-        sig: &Signature,
-        body: &mut Block,
-    ) -> syn::Result<()> {
+    pub fn instrument_fn(&self, spec: &FnSpec, sig: &Signature, body: &mut Block) -> Result<()> {
         self.instrument_loops_in_fn_body(body)?;
 
         let Mode::InjectChecks(check_config) = self else {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -12,7 +12,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, PostCondition, Spec,
+    Capture, Condition, FnSpec, PostCondition,
     instrument::{
         CheckSettings, Mode,
         patterns::{IdentGenerator, TamePat, tame_pattern},
@@ -21,7 +21,12 @@ use crate::{
 };
 
 impl Mode {
-    pub fn instrument_fn(&self, spec: &Spec, sig: &Signature, body: &mut Block) -> syn::Result<()> {
+    pub fn instrument_fn(
+        &self,
+        spec: &FnSpec,
+        sig: &Signature,
+        body: &mut Block,
+    ) -> syn::Result<()> {
         self.instrument_loops_in_fn_body(body)?;
 
         let Mode::InjectChecks(check_config) = self else {
@@ -202,7 +207,7 @@ impl Mode {
 impl CheckSettings {
     fn instrument_fn_body(
         &self,
-        spec: &Spec,
+        spec: &FnSpec,
         original_body: &Block,
         is_async: bool,
         return_type: &ReturnType,

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -375,7 +375,10 @@ fn simple_ensures() {
 #[test]
 fn simple_requires_and_maintains() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(requires: CONDITION_1, maintains: CONDITION_2)]
+        #[spec(
+            requires: CONDITION_1,
+            maintains: CONDITION_2,
+        )]
         fn FUNCTION() -> RET_TYPE { BODY }
     };
 
@@ -414,7 +417,10 @@ fn simple_requires_and_maintains() {
 #[test]
 fn simple_requires_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(requires: CONDITION_1, ensures: CONDITION_2)]
+        #[spec(
+            requires: CONDITION_1,
+            ensures: CONDITION_2,
+        )]
         fn FUNCTION() -> RET_TYPE { BODY }
     };
 
@@ -451,7 +457,10 @@ fn simple_requires_and_ensures() {
 #[test]
 fn simple_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(maintains: CONDITION_1, ensures: CONDITION_2)]
+        #[spec(
+            maintains: CONDITION_1,
+            ensures: CONDITION_2,
+        )]
         fn FUNCTION() -> RET_TYPE { BODY }
     };
 
@@ -490,7 +499,11 @@ fn simple_maintains_and_ensures() {
 #[test]
 fn simple_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
+        #[spec(
+            requires: CONDITION_1,
+            maintains: CONDITION_2,
+            ensures: CONDITION_3,
+        )]
         fn FUNCTION() -> RET_TYPE { BODY }
     };
 
@@ -531,7 +544,11 @@ fn simple_requires_maintains_and_ensures() {
 #[test]
 fn simple_async_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
+        #[spec(
+            requires: CONDITION_1,
+            maintains: CONDITION_2,
+            ensures: CONDITION_3,
+        )]
         async fn FUNCTION() -> RET_TYPE { BODY }
     };
 

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -76,7 +76,7 @@ fn embed_spec_item_fn() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
@@ -122,7 +122,7 @@ fn default_instrument_item_fn() {
     };
 
     let observed = Mode::DEFAULT
-        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
@@ -200,7 +200,7 @@ fn emit_try_fn_instrument_item_fn() {
     };
 
     let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
-        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
@@ -232,9 +232,9 @@ fn simple_requires() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -250,9 +250,9 @@ fn requires_disable_runtime_checks() {
     let observed = CheckSettings::DEFAULT
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     let expected: Block = parse_quote! {
@@ -292,9 +292,9 @@ fn requires_no_panic_runtime() {
     let observed = CheckSettings::PRINT
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -329,9 +329,9 @@ fn simple_maintains() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -364,9 +364,9 @@ fn simple_ensures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -403,9 +403,9 @@ fn simple_requires_and_maintains() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -440,9 +440,9 @@ fn simple_requires_and_ensures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -479,9 +479,9 @@ fn simple_maintains_and_ensures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -520,9 +520,9 @@ fn simple_requires_maintains_and_ensures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -561,9 +561,9 @@ fn simple_async_requires_maintains_and_ensures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -614,9 +614,9 @@ fn multiple_conditions_in_clauses() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -652,9 +652,9 @@ fn postcond_closure_form() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -695,9 +695,9 @@ fn postcond_borrowing_closure_form() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -741,9 +741,9 @@ fn ensures_with_mixed_conditions() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -789,9 +789,9 @@ fn cfg_attributes() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -842,9 +842,9 @@ fn cfg_on_single_and_list_conditions() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -909,9 +909,9 @@ fn complex_mixed_conditions() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
@@ -962,9 +962,9 @@ fn captures() {
     let observed = CheckSettings::PRINT_AND_PANIC
         .instrument_fn_body(
             &spec_item_fn.spec,
-            &spec_item_fn.item.block,
-            spec_item_fn.item.sig.asyncness.is_some(),
-            &spec_item_fn.item.sig.output,
+            &spec_item_fn.node.block,
+            spec_item_fn.node.sig.asyncness.is_some(),
+            &spec_item_fn.node.sig.output,
         )
         .unwrap();
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -1,4 +1,4 @@
-use crate::{SpecItemFn, test_util::assert_tokens_eq};
+use crate::test_util::{SpecItemFn, assert_tokens_eq};
 
 use super::*;
 use proc_macro2::TokenStream;

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -209,7 +209,7 @@ fn emit_try_fn_instrument_item_fn() {
 fn simple_requires() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -220,7 +220,7 @@ fn simple_requires() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -244,7 +244,7 @@ fn simple_requires() {
 fn requires_disable_runtime_checks() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let observed = CheckSettings::DEFAULT
@@ -260,7 +260,7 @@ fn requires_disable_runtime_checks() {
             let __anodized_pre = true;
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -273,7 +273,7 @@ fn requires_disable_runtime_checks() {
 fn requires_no_panic_runtime() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -282,7 +282,7 @@ fn requires_no_panic_runtime() {
             let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -304,7 +304,7 @@ fn requires_no_panic_runtime() {
 fn simple_maintains() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(maintains: CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -315,7 +315,7 @@ fn simple_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -341,7 +341,7 @@ fn simple_maintains() {
 fn simple_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -350,7 +350,7 @@ fn simple_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -376,7 +376,7 @@ fn simple_ensures() {
 fn simple_requires_and_maintains() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -389,7 +389,7 @@ fn simple_requires_and_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -415,7 +415,7 @@ fn simple_requires_and_maintains() {
 fn simple_requires_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, ensures: CONDITION_2)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -426,7 +426,7 @@ fn simple_requires_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -452,7 +452,7 @@ fn simple_requires_and_ensures() {
 fn simple_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(maintains: CONDITION_1, ensures: CONDITION_2)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -463,7 +463,7 @@ fn simple_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -491,7 +491,7 @@ fn simple_maintains_and_ensures() {
 fn simple_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -504,7 +504,7 @@ fn simple_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -532,7 +532,7 @@ fn simple_requires_maintains_and_ensures() {
 fn simple_async_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
-        async fn FUNCTION() -> SomeType { BODY }
+        async fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -545,7 +545,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(async || -> SomeType { BODY }).await);
+            let (__anodized_output) = (::anodized::__::eval_once(async || -> RET_TYPE { BODY }).await);
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -577,7 +577,7 @@ fn multiple_conditions_in_clauses() {
             maintains: [CONDITION_3, CONDITION_4],
             ensures: [CONDITION_5, CONDITION_6],
         )]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -594,7 +594,7 @@ fn multiple_conditions_in_clauses() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
@@ -626,7 +626,7 @@ fn multiple_conditions_in_clauses() {
 fn postcond_closure_form() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: |OUTPUT_PATTERN| CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -635,7 +635,7 @@ fn postcond_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |OUTPUT_PATTERN| (__anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
@@ -664,7 +664,7 @@ fn postcond_closure_form() {
 fn postcond_borrowing_closure_form() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: |ref OUTPUT_PATTERN| CONDITION_1)]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -673,7 +673,7 @@ fn postcond_borrowing_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |__anodized_output| {
@@ -712,7 +712,7 @@ fn ensures_with_mixed_conditions() {
             CONDITION_3,
             CONDITION_4
         ])]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -721,7 +721,7 @@ fn ensures_with_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -760,7 +760,7 @@ fn cfg_attributes() {
             #[cfg(SETTING_3)]
             ensures: CONDITION_3,
         )]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -773,7 +773,7 @@ fn cfg_attributes() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -807,7 +807,7 @@ fn cfg_on_single_and_list_conditions() {
             #[cfg(SETTING_2)]
             ensures: [CONDITION_4, CONDITION_5],
         )]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -822,7 +822,7 @@ fn cfg_on_single_and_list_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -864,7 +864,7 @@ fn complex_mixed_conditions() {
             #[cfg(SETTING_3)]
             ensures: [CONDITION_8, CONDITION_9],
         )]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -885,7 +885,7 @@ fn complex_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
@@ -931,7 +931,7 @@ fn captures() {
                 CONDITION_3,
             ],
         )]
-        fn FUNCTION() -> SomeType { BODY }
+        fn FUNCTION() -> RET_TYPE { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -945,7 +945,7 @@ fn captures() {
             let (ALIAS_1, ALIAS_2, __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
-                ::anodized::__::eval_once(|| -> SomeType { BODY }),
+                ::anodized::__::eval_once(|| -> RET_TYPE { BODY }),
             );
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -1,10 +1,31 @@
-use crate::test_util::assert_tokens_eq;
+use crate::{SpecItemFn, annotate::syntax::SpecFields, test_util::assert_tokens_eq};
 
 use super::*;
 use proc_macro2::TokenStream;
 use syn::{Block, ItemFn, parse_quote};
 
-fn make_complex_spec() -> Spec {
+fn DEPRECATED_make_complex_spec() -> Spec {
+    parse_quote! {
+        requires: COND_1,
+        #[cfg(META_1)]
+        requires: [COND_2, COND_3],
+        maintains: [COND_4, COND_5],
+        #[cfg(META_2)]
+        maintains: COND_6,
+        captures: [
+            ALIAS_1 = EXPR_1,
+            (ALIAS_2, ALIAS_3) = EXPR_2,
+        ],
+        ensures: |PAT_1| COND_7,
+        #[cfg(META_3)]
+        ensures: |PAT_1| [
+            COND_8,
+            COND_9,
+        ],
+    }
+}
+
+fn make_complex_spec() -> SpecFields {
     parse_quote! {
         requires: COND_1,
         #[cfg(META_1)]
@@ -27,8 +48,9 @@ fn make_complex_spec() -> Spec {
 
 #[test]
 fn embed_spec_item_fn() {
-    let fn_spec = make_complex_spec();
-    let item_fn: ItemFn = parse_quote! {
+    let spec_fields = make_complex_spec();
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(#spec_fields)]
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY
         }
@@ -76,14 +98,14 @@ fn embed_spec_item_fn() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_fn(fn_spec, item_fn)
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn default_instrument_item_fn() {
-    let fn_spec = make_complex_spec();
+    let fn_spec = DEPRECATED_make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY
@@ -132,7 +154,7 @@ fn default_instrument_item_fn() {
 
 #[test]
 fn emit_try_fn_instrument_item_fn() {
-    let fn_spec = make_complex_spec();
+    let fn_spec = DEPRECATED_make_complex_spec();
     let item_fn: ItemFn = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
             BODY

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -209,7 +209,7 @@ fn emit_try_fn_instrument_item_fn() {
 fn simple_requires() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -220,7 +220,7 @@ fn simple_requires() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -244,7 +244,7 @@ fn simple_requires() {
 fn requires_disable_runtime_checks() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let observed = CheckSettings::DEFAULT
@@ -260,7 +260,7 @@ fn requires_disable_runtime_checks() {
             let __anodized_pre = true;
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -273,7 +273,7 @@ fn requires_disable_runtime_checks() {
 fn requires_no_panic_runtime() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -282,7 +282,7 @@ fn requires_no_panic_runtime() {
             let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -304,7 +304,7 @@ fn requires_no_panic_runtime() {
 fn simple_maintains() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(maintains: CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -315,7 +315,7 @@ fn simple_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -341,7 +341,7 @@ fn simple_maintains() {
 fn simple_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -350,7 +350,7 @@ fn simple_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -376,7 +376,7 @@ fn simple_ensures() {
 fn simple_requires_and_maintains() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -389,7 +389,7 @@ fn simple_requires_and_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -415,7 +415,7 @@ fn simple_requires_and_maintains() {
 fn simple_requires_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, ensures: CONDITION_2)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -426,7 +426,7 @@ fn simple_requires_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -452,7 +452,7 @@ fn simple_requires_and_ensures() {
 fn simple_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(maintains: CONDITION_1, ensures: CONDITION_2)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -463,7 +463,7 @@ fn simple_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -491,7 +491,7 @@ fn simple_maintains_and_ensures() {
 fn simple_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -504,7 +504,7 @@ fn simple_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -532,7 +532,7 @@ fn simple_requires_maintains_and_ensures() {
 fn simple_async_requires_maintains_and_ensures() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
-        async fn FUNCTION() -> SomeType { this_is_the_body() }
+        async fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -545,7 +545,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(async || -> SomeType { this_is_the_body() }).await);
+            let (__anodized_output) = (::anodized::__::eval_once(async || -> SomeType { BODY }).await);
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -577,7 +577,7 @@ fn multiple_conditions_in_clauses() {
             maintains: [CONDITION_3, CONDITION_4],
             ensures: [CONDITION_5, CONDITION_6],
         )]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -594,7 +594,7 @@ fn multiple_conditions_in_clauses() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
@@ -626,7 +626,7 @@ fn multiple_conditions_in_clauses() {
 fn postcond_closure_form() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: |OUTPUT_PATTERN| CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -635,7 +635,7 @@ fn postcond_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |OUTPUT_PATTERN| (__anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
@@ -664,7 +664,7 @@ fn postcond_closure_form() {
 fn postcond_borrowing_closure_form() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(ensures: |ref OUTPUT_PATTERN| CONDITION_1)]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -673,7 +673,7 @@ fn postcond_borrowing_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |__anodized_output| {
@@ -712,7 +712,7 @@ fn ensures_with_mixed_conditions() {
             CONDITION_3,
             CONDITION_4
         ])]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -721,7 +721,7 @@ fn ensures_with_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -760,7 +760,7 @@ fn cfg_attributes() {
             #[cfg(SETTING_3)]
             ensures: CONDITION_3,
         )]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -773,7 +773,7 @@ fn cfg_attributes() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -807,7 +807,7 @@ fn cfg_on_single_and_list_conditions() {
             #[cfg(SETTING_2)]
             ensures: [CONDITION_4, CONDITION_5],
         )]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -822,7 +822,7 @@ fn cfg_on_single_and_list_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -864,7 +864,7 @@ fn complex_mixed_conditions() {
             #[cfg(SETTING_3)]
             ensures: [CONDITION_8, CONDITION_9],
         )]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -885,7 +885,7 @@ fn complex_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { BODY }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
@@ -931,7 +931,7 @@ fn captures() {
                 CONDITION_3,
             ],
         )]
-        fn FUNCTION() -> SomeType { this_is_the_body() }
+        fn FUNCTION() -> SomeType { BODY }
     };
 
     let expected: Block = parse_quote! {
@@ -945,7 +945,7 @@ fn captures() {
             let (ALIAS_1, ALIAS_2, __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
-                ::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }),
+                ::anodized::__::eval_once(|| -> SomeType { BODY }),
             );
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -1,60 +1,38 @@
-use crate::{SpecItemFn, annotate::syntax::SpecFields, test_util::assert_tokens_eq};
+use crate::{SpecItemFn, test_util::assert_tokens_eq};
 
 use super::*;
 use proc_macro2::TokenStream;
-use syn::{Block, ItemFn, parse_quote};
+use syn::{Block, parse_quote};
 
-fn DEPRECATED_make_complex_spec() -> Spec {
+fn make_complex_spec_item_fn() -> SpecItemFn {
     parse_quote! {
-        requires: COND_1,
-        #[cfg(META_1)]
-        requires: [COND_2, COND_3],
-        maintains: [COND_4, COND_5],
-        #[cfg(META_2)]
-        maintains: COND_6,
-        captures: [
-            ALIAS_1 = EXPR_1,
-            (ALIAS_2, ALIAS_3) = EXPR_2,
-        ],
-        ensures: |PAT_1| COND_7,
-        #[cfg(META_3)]
-        ensures: |PAT_1| [
-            COND_8,
-            COND_9,
-        ],
-    }
-}
-
-fn make_complex_spec() -> SpecFields {
-    parse_quote! {
-        requires: COND_1,
-        #[cfg(META_1)]
-        requires: [COND_2, COND_3],
-        maintains: [COND_4, COND_5],
-        #[cfg(META_2)]
-        maintains: COND_6,
-        captures: [
-            ALIAS_1 = EXPR_1,
-            (ALIAS_2, ALIAS_3) = EXPR_2,
-        ],
-        ensures: |PAT_1| COND_7,
-        #[cfg(META_3)]
-        ensures: |PAT_1| [
-            COND_8,
-            COND_9,
-        ],
+        #[spec(
+            requires: COND_1,
+            #[cfg(META_1)]
+            requires: [COND_2, COND_3],
+            maintains: [COND_4, COND_5],
+            #[cfg(META_2)]
+            maintains: COND_6,
+            captures: [
+                ALIAS_1 = EXPR_1,
+                (ALIAS_2, ALIAS_3) = EXPR_2,
+            ],
+            ensures: |PAT_1| COND_7,
+            #[cfg(META_3)]
+            ensures: |PAT_1| [
+                COND_8,
+                COND_9,
+            ],
+        )]
+        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
+            BODY
+        }
     }
 }
 
 #[test]
 fn embed_spec_item_fn() {
-    let spec_fields = make_complex_spec();
-    let spec_item_fn: SpecItemFn = parse_quote! {
-        #[spec(#spec_fields)]
-        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            BODY
-        }
-    };
+    let spec_item_fn = make_complex_spec_item_fn();
 
     let qualifier_bits = FnQualifiers::empty().bits();
     let expected: TokenStream = parse_quote! {
@@ -105,12 +83,7 @@ fn embed_spec_item_fn() {
 
 #[test]
 fn default_instrument_item_fn() {
-    let fn_spec = DEPRECATED_make_complex_spec();
-    let item_fn: ItemFn = parse_quote! {
-        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            BODY
-        }
-    };
+    let spec_item_fn = make_complex_spec_item_fn();
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
@@ -148,18 +121,15 @@ fn default_instrument_item_fn() {
         }
     };
 
-    let observed = Mode::DEFAULT.instrument_item_fn(fn_spec, item_fn).unwrap();
+    let observed = Mode::DEFAULT
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
+        .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn emit_try_fn_instrument_item_fn() {
-    let fn_spec = DEPRECATED_make_complex_spec();
-    let item_fn: ItemFn = parse_quote! {
-        fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {
-            BODY
-        }
-    };
+    let spec_item_fn = make_complex_spec_item_fn();
 
     let expected: TokenStream = parse_quote! {
         fn FUNC(&self, input_1: TYPE_1, input_2: TYPE_2) -> RET_TYPE {
@@ -230,31 +200,17 @@ fn emit_try_fn_instrument_item_fn() {
     };
 
     let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
-        .instrument_item_fn(fn_spec, item_fn)
+        .instrument_item_fn(spec_item_fn.spec, spec_item_fn.item)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
-fn make_fn_body() -> Block {
-    parse_quote! {
-        {
-            this_is_the_body()
-        }
-    }
-}
-
-fn make_return_type() -> ReturnType {
-    parse_quote! { -> SomeType }
-}
-
 #[test]
 fn simple_requires() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -264,7 +220,7 @@ fn simple_requires() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -274,29 +230,37 @@ fn simple_requires() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn requires_disable_runtime_checks() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let observed = CheckSettings::DEFAULT
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     let expected: Block = parse_quote! {
         {
             let __anodized_pre = true;
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -307,12 +271,10 @@ fn requires_disable_runtime_checks() {
 
 #[test]
 fn requires_no_panic_runtime() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -320,7 +282,7 @@ fn requires_no_panic_runtime() {
             let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -328,19 +290,22 @@ fn requires_no_panic_runtime() {
     };
 
     let observed = CheckSettings::PRINT
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_maintains() {
-    let spec: Spec = parse_quote! {
-        maintains: CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(maintains: CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -350,7 +315,7 @@ fn simple_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -362,19 +327,22 @@ fn simple_maintains() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_ensures() {
-    let spec: Spec = parse_quote! {
-        ensures: CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(ensures: CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -382,7 +350,7 @@ fn simple_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -394,20 +362,22 @@ fn simple_ensures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_requires_and_maintains() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        maintains: CONDITION_2,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1, maintains: CONDITION_2)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -419,7 +389,7 @@ fn simple_requires_and_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -431,20 +401,22 @@ fn simple_requires_and_maintains() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_requires_and_ensures() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        ensures: CONDITION_2,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1, ensures: CONDITION_2)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -454,7 +426,7 @@ fn simple_requires_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -466,20 +438,22 @@ fn simple_requires_and_ensures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_maintains_and_ensures() {
-    let spec: Spec = parse_quote! {
-        maintains: CONDITION_1,
-        ensures: CONDITION_2,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(maintains: CONDITION_1, ensures: CONDITION_2)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -489,7 +463,7 @@ fn simple_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -503,21 +477,22 @@ fn simple_maintains_and_ensures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_requires_maintains_and_ensures() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        maintains: CONDITION_2,
-        ensures: CONDITION_3,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -529,7 +504,7 @@ fn simple_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -543,21 +518,22 @@ fn simple_requires_maintains_and_ensures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn simple_async_requires_maintains_and_ensures() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        maintains: CONDITION_2,
-        ensures: CONDITION_3,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(requires: CONDITION_1, maintains: CONDITION_2, ensures: CONDITION_3)]
+        async fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = true;
 
     let expected: Block = parse_quote! {
         {
@@ -569,7 +545,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(async || #ret_type #body).await);
+            let (__anodized_output) = (::anodized::__::eval_once(async || -> SomeType { this_is_the_body() }).await);
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -583,21 +559,26 @@ fn simple_async_requires_maintains_and_ensures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn multiple_conditions_in_clauses() {
-    let spec: Spec = parse_quote! {
-        requires: [CONDITION_1, CONDITION_2],
-        maintains: [CONDITION_3, CONDITION_4],
-        ensures: [CONDITION_5, CONDITION_6],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: [CONDITION_1, CONDITION_2],
+            maintains: [CONDITION_3, CONDITION_4],
+            ensures: [CONDITION_5, CONDITION_6],
+        )]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -613,7 +594,7 @@ fn multiple_conditions_in_clauses() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
@@ -631,19 +612,22 @@ fn multiple_conditions_in_clauses() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn postcond_closure_form() {
-    let spec: Spec = parse_quote! {
-        ensures: |OUTPUT_PATTERN| CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(ensures: |OUTPUT_PATTERN| CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -651,7 +635,7 @@ fn postcond_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |OUTPUT_PATTERN| (__anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
@@ -666,19 +650,22 @@ fn postcond_closure_form() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn postcond_borrowing_closure_form() {
-    let spec: Spec = parse_quote! {
-        ensures: |ref OUTPUT_PATTERN| CONDITION_1,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(ensures: |ref OUTPUT_PATTERN| CONDITION_1)]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -686,7 +673,7 @@ fn postcond_borrowing_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |__anodized_output| {
@@ -706,24 +693,27 @@ fn postcond_borrowing_closure_form() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn ensures_with_mixed_conditions() {
-    let spec: Spec = parse_quote! {
-        ensures: [
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(ensures: [
             CONDITION_1,
             CONDITION_2,
             CONDITION_3,
             CONDITION_4
-        ],
+        ])]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -731,7 +721,7 @@ fn ensures_with_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -749,24 +739,29 @@ fn ensures_with_mixed_conditions() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn cfg_attributes() {
-    let spec: Spec = parse_quote! {
-        #[cfg(SETTING_1)]
-        requires: CONDITION_1,
-        #[cfg(SETTING_2)]
-        maintains: CONDITION_2,
-        #[cfg(SETTING_3)]
-        ensures: CONDITION_3,
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(SETTING_1)]
+            requires: CONDITION_1,
+            #[cfg(SETTING_2)]
+            maintains: CONDITION_2,
+            #[cfg(SETTING_3)]
+            ensures: CONDITION_3,
+        )]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -778,7 +773,7 @@ fn cfg_attributes() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -792,23 +787,28 @@ fn cfg_attributes() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn cfg_on_single_and_list_conditions() {
-    let spec: Spec = parse_quote! {
-        #[cfg(SETTING_1)]
-        requires: CONDITION_1,
-        maintains: [CONDITION_2, CONDITION_3],
-        #[cfg(SETTING_2)]
-        ensures: [CONDITION_4, CONDITION_5],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            #[cfg(SETTING_1)]
+            requires: CONDITION_1,
+            maintains: [CONDITION_2, CONDITION_3],
+            #[cfg(SETTING_2)]
+            ensures: [CONDITION_4, CONDITION_5],
+        )]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -822,7 +822,7 @@ fn cfg_on_single_and_list_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -840,27 +840,32 @@ fn cfg_on_single_and_list_conditions() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn complex_mixed_conditions() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        #[cfg(SETTING_1)]
-        requires: [CONDITION_2, CONDITION_3],
-        maintains: [CONDITION_4, CONDITION_5],
-        #[cfg(SETTING_2)]
-        maintains: CONDITION_6,
-        ensures: CONDITION_7,
-        #[cfg(SETTING_3)]
-        ensures: [CONDITION_8, CONDITION_9],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: CONDITION_1,
+            #[cfg(SETTING_1)]
+            requires: [CONDITION_2, CONDITION_3],
+            maintains: [CONDITION_4, CONDITION_5],
+            #[cfg(SETTING_2)]
+            maintains: CONDITION_6,
+            ensures: CONDITION_7,
+            #[cfg(SETTING_3)]
+            ensures: [CONDITION_8, CONDITION_9],
+        )]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -880,7 +885,7 @@ fn complex_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| #ret_type #body));
+            let (__anodized_output) = (::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }));
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());
@@ -902,27 +907,32 @@ fn complex_mixed_conditions() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn captures() {
-    let spec: Spec = parse_quote! {
-        requires: CONDITION_1,
-        captures: [
-            ALIAS_1 = EXPR_1,
-            ALIAS_2 = EXPR_2,
-        ],
-        ensures: [
-            CONDITION_2,
-            CONDITION_3,
-        ],
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec(
+            requires: CONDITION_1,
+            captures: [
+                ALIAS_1 = EXPR_1,
+                ALIAS_2 = EXPR_2,
+            ],
+            ensures: [
+                CONDITION_2,
+                CONDITION_3,
+            ],
+        )]
+        fn FUNCTION() -> SomeType { this_is_the_body() }
     };
-    let body = make_fn_body();
-    let ret_type = make_return_type();
-    let is_async = false;
 
     let expected: Block = parse_quote! {
         {
@@ -935,7 +945,7 @@ fn captures() {
             let (ALIAS_1, ALIAS_2, __anodized_output) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
-                ::anodized::__::eval_once(|| #ret_type #body),
+                ::anodized::__::eval_once(|| -> SomeType { this_is_the_body() }),
             );
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
@@ -950,7 +960,12 @@ fn captures() {
     };
 
     let observed = CheckSettings::PRINT_AND_PANIC
-        .instrument_fn_body(&spec, &body, is_async, &ret_type)
+        .instrument_fn_body(
+            &spec_item_fn.spec,
+            &spec_item_fn.item.block,
+            spec_item_fn.item.sig.asyncness.is_some(),
+            &spec_item_fn.item.sig.output,
+        )
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -2,14 +2,13 @@
 #[path = "impls_tests.rs"]
 mod impls_tests;
 
-use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, ImplItem, ImplItemFn, ItemImpl, Result, ReturnType, Visibility, parse_quote,
 };
 
 use crate::{
     DataSpec, SpecImplItemFn,
-    annotate::{Specify as _, get_attr_input, remove_spec_attr},
+    annotate::{Specify as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -31,9 +30,7 @@ impl Mode {
 
         for item in the_impl.items.into_iter() {
             match item {
-                ImplItem::Fn(mut item_fn) => {
-                    let spec_attr = remove_spec_attr(&mut item_fn.attrs)?;
-
+                ImplItem::Fn(item_fn) => {
                     if item_fn.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(Error::new_spanned(
                             item_fn.sig.ident,
@@ -42,14 +39,10 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let spec_input = match spec_attr {
-                        Some(spec_attr) => get_attr_input(spec_attr)?,
-                        None => TokenStream::new(),
-                    };
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut item_fn,
-                    } = item_fn.parse_spec(spec_input)?;
+                    } = item_fn.parse_spec_attr()?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -9,7 +9,7 @@ use syn::{
 
 use crate::{
     DataSpec, Spec,
-    annotate::get_attr_input,
+    annotate::{get_attr_input, remove_spec_attr},
     instrument::{Mode, find_spec_attr, make_item_error},
 };
 
@@ -32,8 +32,7 @@ impl Mode {
         for item in the_impl.items.into_iter() {
             match item {
                 ImplItem::Fn(mut item_fn) => {
-                    let (spec_attr, func_attrs) = find_spec_attr(item_fn.attrs)?;
-                    item_fn.attrs = func_attrs;
+                    let spec_attr = remove_spec_attr(&mut item_fn.attrs)?;
 
                     if item_fn.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(Error::new_spanned(

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -10,7 +10,7 @@ use syn::{
 use crate::{
     DataSpec, Spec,
     annotate::{get_attr_input, remove_spec_attr},
-    instrument::{Mode, find_spec_attr, make_item_error},
+    instrument::{Mode, make_item_error},
 };
 
 impl Mode {
@@ -126,27 +126,21 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                     new_items.push(ImplItem::Fn(item_fn));
                 }
                 ImplItem::Const(mut const_item) => {
-                    let (spec, attrs) = find_spec_attr(const_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl const"));
                     }
-                    const_item.attrs = attrs;
                     new_items.push(ImplItem::Const(const_item));
                 }
                 ImplItem::Type(mut type_item) => {
-                    let (spec, attrs) = find_spec_attr(type_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl type"));
                     }
-                    type_item.attrs = attrs;
                     new_items.push(ImplItem::Type(type_item));
                 }
                 ImplItem::Macro(mut macro_item) => {
-                    let (spec, attrs) = find_spec_attr(macro_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl macro"));
                     }
-                    macro_item.attrs = attrs;
                     new_items.push(ImplItem::Macro(macro_item));
                 }
                 ImplItem::Verbatim(token_stream) => {

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec, SpecImplItemFn,
+    DataSpec,
     annotate::{Specified as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
@@ -30,7 +30,7 @@ impl Mode {
 
         for item in the_impl.items.into_iter() {
             match item {
-                ImplItem::Fn(item_fn) => {
+                ImplItem::Fn(mut item_fn) => {
                     if item_fn.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(Error::new_spanned(
                             item_fn.sig.ident,
@@ -39,10 +39,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let SpecImplItemFn {
-                        spec: fn_spec,
-                        node: mut item_fn,
-                    } = item_fn.with_spec_from_attrs()?;
+                    let fn_spec = item_fn.with_spec_from_attrs()?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -8,7 +8,7 @@ use syn::{
 
 use crate::{
     DataSpec,
-    annotate::{Specified as _, remove_spec_attr},
+    annotate::{Specified as _, syntax::remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -9,7 +9,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn,
-    annotate::{ParseOnItem as _, get_attr_input, remove_spec_attr},
+    annotate::{Specify as _, get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -49,7 +49,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut item_fn,
-                    } = SpecImplItemFn::parse_spec_on(item_fn, spec_input)?;
+                    } = item_fn.parse_spec(spec_input)?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -8,7 +8,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn,
-    annotate::{Specify as _, remove_spec_attr},
+    annotate::{Specified as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -41,8 +41,8 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
 
                     let SpecImplItemFn {
                         spec: fn_spec,
-                        item: mut item_fn,
-                    } = item_fn.with_spec_attr()?;
+                        node: mut item_fn,
+                    } = item_fn.with_spec_from_attrs()?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -8,7 +8,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec, Spec,
+    DataSpec, SpecImplItemFn,
     annotate::{get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
@@ -46,7 +46,10 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         Some(spec_attr) => get_attr_input(spec_attr)?,
                         None => TokenStream::new(),
                     };
-                    let fn_spec: Spec = syn::parse2(spec_input)?;
+                    let SpecImplItemFn {
+                        spec: fn_spec,
+                        item: mut item_fn,
+                    } = SpecImplItemFn::parse_spec_on(item_fn, spec_input)?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -39,7 +39,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let fn_spec = item_fn.with_spec_from_attrs()?;
+                    let fn_spec = item_fn.parse_spec_from_attrs()?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -2,12 +2,14 @@
 #[path = "impls_tests.rs"]
 mod impls_tests;
 
+use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, ImplItem, ImplItemFn, ItemImpl, Result, ReturnType, Visibility, parse_quote,
 };
 
 use crate::{
     DataSpec, Spec,
+    annotate::get_attr_input,
     instrument::{Mode, find_spec_attr, make_item_error},
 };
 
@@ -41,10 +43,11 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let fn_spec: Spec = match spec_attr {
-                        Some(spec_attr) => spec_attr.parse_args()?,
-                        None => Spec::empty(),
+                    let spec_input = match spec_attr {
+                        Some(spec_attr) => get_attr_input(spec_attr)?,
+                        None => TokenStream::new(),
                     };
+                    let fn_spec: Spec = syn::parse2(spec_input)?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -9,7 +9,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn,
-    annotate::{get_attr_input, remove_spec_attr},
+    annotate::{ParseOnItem as _, get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -42,7 +42,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut item_fn,
-                    } = item_fn.parse_spec_attr()?;
+                    } = item_fn.with_spec_attr()?;
 
                     if let Self::EmbedSpecs = self {
                         // Embed `spec` elements as `__anodized_fn_*` items.

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -1,13 +1,17 @@
-use crate::{instrument::CheckSettings, qualifiers::FnQualifiers, test_util::assert_tokens_eq};
+use crate::{
+    instrument::CheckSettings,
+    qualifiers::FnQualifiers,
+    test_util::{SpecItemImpl, assert_tokens_eq},
+};
 
 use super::*;
 use proc_macro2::TokenStream;
-use syn::{ItemImpl, parse_quote};
+use syn::parse_quote;
 
 #[test]
 fn embed_spec_item_impl() {
-    let impl_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -51,15 +55,15 @@ fn embed_spec_item_impl() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_impl(impl_spec, item_impl)
+        .instrument_item_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn default_instrument_item_impl() {
-    let impl_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -93,15 +97,15 @@ fn default_instrument_item_impl() {
     };
 
     let observed = Mode::DEFAULT
-        .instrument_item_impl(impl_spec, item_impl)
+        .instrument_item_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn emit_try_fn_instrument_item_impl() {
-    let impl_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -160,7 +164,7 @@ fn emit_try_fn_instrument_item_impl() {
     };
 
     let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
-        .instrument_item_impl(impl_spec, item_impl)
+        .instrument_item_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -9,7 +9,7 @@ use syn::{
     visit_mut::{self, VisitMut},
 };
 
-use crate::{LoopSpec, annotate::remove_spec_attr, instrument::Mode};
+use crate::{LoopSpec, annotate::Specified, instrument::Mode};
 
 impl Mode {
     pub fn instrument_loops_in_fn_body(&self, body: &mut Block) -> Result<()> {
@@ -94,8 +94,8 @@ impl<'a> LoopSpecVisitor<'a> {
 
 impl VisitMut for LoopSpecVisitor<'_> {
     fn visit_expr_while_mut(&mut self, expr_while: &mut ExprWhile) {
-        let spec_attr = match remove_spec_attr(&mut expr_while.attrs) {
-            Ok(spec_attr) => spec_attr,
+        let spec = match expr_while.parse_spec_from_attrs() {
+            Ok(spec) => spec,
             Err(error) => {
                 self.add_error(error);
                 return;
@@ -104,21 +104,17 @@ impl VisitMut for LoopSpecVisitor<'_> {
 
         visit_mut::visit_expr_while_mut(self, expr_while);
 
-        let Some(spec_attr) = spec_attr else {
+        if spec.is_empty() {
             return;
-        };
-
-        match spec_attr.parse_args::<LoopSpec>() {
-            Ok(spec) => self
-                .config
-                .instrument_loop_body(spec, &mut expr_while.body.stmts),
-            Err(error) => self.add_error(error),
         }
+
+        self.config
+            .instrument_loop_body(spec, &mut expr_while.body.stmts);
     }
 
     fn visit_expr_for_loop_mut(&mut self, expr_for_loop: &mut ExprForLoop) {
-        let spec_attr = match remove_spec_attr(&mut expr_for_loop.attrs) {
-            Ok(spec_attr) => spec_attr,
+        let spec = match expr_for_loop.parse_spec_from_attrs() {
+            Ok(spec) => spec,
             Err(error) => {
                 self.add_error(error);
                 return;
@@ -127,14 +123,11 @@ impl VisitMut for LoopSpecVisitor<'_> {
 
         visit_mut::visit_expr_for_loop_mut(self, expr_for_loop);
 
-        let Some(spec_attr) = spec_attr else {
+        if spec.is_empty() {
             return;
-        };
-
-        match spec_attr.parse_args::<LoopSpec>() {
-            Ok(spec) => self.config.instrument_expr_for_loop(spec, expr_for_loop),
-            Err(error) => self.add_error(error),
         }
+
+        self.config.instrument_expr_for_loop(spec, expr_for_loop);
     }
 
     // Nested closure scopes are independently analyzed by the outer function macro expansion.

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -94,40 +94,23 @@ impl<'a> LoopSpecVisitor<'a> {
 
 impl VisitMut for LoopSpecVisitor<'_> {
     fn visit_expr_while_mut(&mut self, expr_while: &mut ExprWhile) {
-        let spec = match expr_while.parse_spec_from_attrs() {
-            Ok(spec) => spec,
-            Err(error) => {
-                self.add_error(error);
-                return;
-            }
-        };
-
         visit_mut::visit_expr_while_mut(self, expr_while);
 
-        if spec.is_empty() {
-            return;
+        match expr_while.parse_spec_from_attrs() {
+            Ok(spec) => self
+                .config
+                .instrument_loop_body(spec, &mut expr_while.body.stmts),
+            Err(error) => self.add_error(error),
         }
-
-        self.config
-            .instrument_loop_body(spec, &mut expr_while.body.stmts);
     }
 
     fn visit_expr_for_loop_mut(&mut self, expr_for_loop: &mut ExprForLoop) {
-        let spec = match expr_for_loop.parse_spec_from_attrs() {
-            Ok(spec) => spec,
-            Err(error) => {
-                self.add_error(error);
-                return;
-            }
-        };
-
         visit_mut::visit_expr_for_loop_mut(self, expr_for_loop);
 
-        if spec.is_empty() {
-            return;
+        match expr_for_loop.parse_spec_from_attrs() {
+            Ok(spec) => self.config.instrument_expr_for_loop(spec, expr_for_loop),
+            Err(error) => self.add_error(error),
         }
-
-        self.config.instrument_expr_for_loop(spec, expr_for_loop);
     }
 
     // Nested closure scopes are independently analyzed by the outer function macro expansion.

--- a/crates/anodized-core/src/instrument/loops.rs
+++ b/crates/anodized-core/src/instrument/loops.rs
@@ -9,10 +9,7 @@ use syn::{
     visit_mut::{self, VisitMut},
 };
 
-use crate::{
-    LoopSpec,
-    instrument::{Mode, find_spec_attr},
-};
+use crate::{LoopSpec, annotate::remove_spec_attr, instrument::Mode};
 
 impl Mode {
     pub fn instrument_loops_in_fn_body(&self, body: &mut Block) -> Result<()> {
@@ -97,15 +94,13 @@ impl<'a> LoopSpecVisitor<'a> {
 
 impl VisitMut for LoopSpecVisitor<'_> {
     fn visit_expr_while_mut(&mut self, expr_while: &mut ExprWhile) {
-        let attrs = std::mem::take(&mut expr_while.attrs);
-        let (spec_attr, other_attrs) = match find_spec_attr(attrs) {
-            Ok(result) => result,
+        let spec_attr = match remove_spec_attr(&mut expr_while.attrs) {
+            Ok(spec_attr) => spec_attr,
             Err(error) => {
                 self.add_error(error);
                 return;
             }
         };
-        expr_while.attrs = other_attrs;
 
         visit_mut::visit_expr_while_mut(self, expr_while);
 
@@ -122,15 +117,13 @@ impl VisitMut for LoopSpecVisitor<'_> {
     }
 
     fn visit_expr_for_loop_mut(&mut self, expr_for_loop: &mut ExprForLoop) {
-        let attrs = std::mem::take(&mut expr_for_loop.attrs);
-        let (spec_attr, other_attrs) = match find_spec_attr(attrs) {
-            Ok(result) => result,
+        let spec_attr = match remove_spec_attr(&mut expr_for_loop.attrs) {
+            Ok(spec_attr) => spec_attr,
             Err(error) => {
                 self.add_error(error);
                 return;
             }
         };
-        expr_for_loop.attrs = other_attrs;
 
         visit_mut::visit_expr_for_loop_mut(self, expr_for_loop);
 

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -1,18 +1,18 @@
 use proc_macro2::TokenStream;
 use syn::{ExprForLoop, ExprWhile, parse_quote};
 
-use crate::{LoopSpec, instrument::Mode, test_util::assert_tokens_eq};
+use crate::{annotate::Specified, instrument::Mode, test_util::assert_tokens_eq};
 
 #[test]
 fn embed_spec_expr_while() {
-    let while_spec: LoopSpec = parse_quote! {
-        maintains: [
-            INVAR_1,
-            INVAR_2,
-        ],
-        decreases: DECREASES_1,
-    };
     let mut expr_while: ExprWhile = parse_quote! {
+        #[spec(
+            maintains: [
+                INVAR_1,
+                INVAR_2,
+            ],
+            decreases: DECREASES_1,
+        )]
         while WHILE_COND {
             LOOP_BODY
         }
@@ -33,7 +33,8 @@ fn embed_spec_expr_while() {
         }
     };
 
-    Mode::EmbedSpecs.instrument_expr_while(while_spec, &mut expr_while);
+    let spec = expr_while.parse_spec_from_attrs().unwrap();
+    Mode::EmbedSpecs.instrument_expr_while(spec, &mut expr_while);
     let observed = expr_while;
 
     assert_tokens_eq(&observed, &expected);
@@ -41,13 +42,13 @@ fn embed_spec_expr_while() {
 
 #[test]
 fn embed_spec_expr_for() {
-    let for_spec: LoopSpec = parse_quote! {
-        maintains: [
-            INVAR_1,
-            INVAR_2,
-        ],
-    };
     let mut expr_for_loop: ExprForLoop = parse_quote! {
+        #[spec(
+            maintains: [
+                INVAR_1,
+                INVAR_2,
+            ],
+        )]
         for FOR_VAR in FOR_EXPR {
             LOOP_BODY
         }
@@ -65,7 +66,8 @@ fn embed_spec_expr_for() {
         }
     };
 
-    Mode::EmbedSpecs.instrument_expr_for_loop(for_spec, &mut expr_for_loop);
+    let spec = expr_for_loop.parse_spec_from_attrs().unwrap();
+    Mode::EmbedSpecs.instrument_expr_for_loop(spec, &mut expr_for_loop);
     let observed = expr_for_loop;
 
     assert_tokens_eq(&observed, &expected);

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -11,7 +11,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn, SpecTraitItemFn,
-    annotate::{ParseOnItem as _, get_attr_input, remove_spec_attr},
+    annotate::{Specify as _, get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -54,7 +54,7 @@ impl Mode {
                     let SpecTraitItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = SpecTraitItemFn::parse_spec_on(func, spec_input)?;
+                    } = func.parse_spec(spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -237,7 +237,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = SpecImplItemFn::parse_spec_on(func, spec_input)?;
+                    } = func.parse_spec(spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -2,7 +2,6 @@
 #[path = "traits_tests.rs"]
 mod traits_tests;
 
-use proc_macro2::TokenStream;
 use syn::{
     Attribute, Block, FnArg, ImplItem, ImplItemFn, Pat, PatConst, PatIdent, PatLit, PatParen,
     PatPath, PatRange, PatSlice, PatStruct, PatTuple, PatTupleStruct, ReturnType, TraitItem,
@@ -11,7 +10,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn, SpecTraitItemFn,
-    annotate::{Specify as _, get_attr_input, remove_spec_attr},
+    annotate::{Specify as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -39,22 +38,17 @@ impl Mode {
 
         for item in the_trait.items.into_iter() {
             match item {
-                TraitItem::Fn(mut func) => {
-                    let spec_attr = remove_spec_attr(&mut func.attrs)?;
+                TraitItem::Fn(func) => {
                     // NOTE: We have no way of knowing which attributes are
                     //   "external" - meant for the interface and belong on the wrapper,
                     //   "internal" - meant for the mangled implementation.
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
 
-                    let spec_input = match spec_attr {
-                        Some(spec_attr) => get_attr_input(spec_attr)?,
-                        None => TokenStream::new(),
-                    };
                     let SpecTraitItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = func.parse_spec(spec_input)?;
+                    } = func.parse_spec_attr()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -219,9 +213,7 @@ impl Mode {
 
         for item in the_impl.items.into_iter() {
             match item {
-                ImplItem::Fn(mut func) => {
-                    let spec_attr = remove_spec_attr(&mut func.attrs)?;
-
+                ImplItem::Fn(func) => {
                     if func.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(syn::Error::new_spanned(
                             func.sig.ident,
@@ -230,14 +222,10 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let spec_input = match spec_attr {
-                        Some(spec_attr) => get_attr_input(spec_attr)?,
-                        None => TokenStream::new(),
-                    };
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = func.parse_spec(spec_input)?;
+                    } = func.parse_spec_attr()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -11,7 +11,7 @@ use syn::{
 
 use crate::{
     DataSpec, Spec,
-    annotate::get_attr_input,
+    annotate::{get_attr_input, remove_spec_attr},
     instrument::{Mode, find_spec_attr, make_item_error},
 };
 
@@ -40,8 +40,7 @@ impl Mode {
         for item in the_trait.items.into_iter() {
             match item {
                 TraitItem::Fn(mut func) => {
-                    let (spec_attr, other_attrs) = find_spec_attr(func.attrs)?;
-                    func.attrs = other_attrs;
+                    let spec_attr = remove_spec_attr(&mut func.attrs)?;
                     // NOTE: We have no way of knowing which attributes are
                     //   "external" - meant for the interface and belong on the wrapper,
                     //   "internal" - meant for the mangled implementation.
@@ -224,8 +223,7 @@ impl Mode {
         for item in the_impl.items.into_iter() {
             match item {
                 ImplItem::Fn(mut func) => {
-                    let (spec_attr, func_attrs) = find_spec_attr(func.attrs)?;
-                    func.attrs = func_attrs;
+                    let spec_attr = remove_spec_attr(&mut func.attrs)?;
 
                     if func.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(syn::Error::new_spanned(

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -10,7 +10,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec, Spec,
+    DataSpec, SpecImplItemFn, SpecTraitItemFn,
     annotate::{get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
@@ -51,7 +51,10 @@ impl Mode {
                         Some(spec_attr) => get_attr_input(spec_attr)?,
                         None => TokenStream::new(),
                     };
-                    let fn_spec: Spec = syn::parse2(spec_input)?;
+                    let SpecTraitItemFn {
+                        spec: fn_spec,
+                        item: mut func,
+                    } = SpecTraitItemFn::parse_spec_on(func, spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -231,7 +234,10 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         Some(spec_attr) => get_attr_input(spec_attr)?,
                         None => TokenStream::new(),
                     };
-                    let fn_spec: Spec = syn::parse2(spec_input)?;
+                    let SpecImplItemFn {
+                        spec: fn_spec,
+                        item: mut func,
+                    } = SpecImplItemFn::parse_spec_on(func, spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -9,7 +9,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec, SpecImplItemFn, SpecTraitItemFn,
+    DataSpec,
     annotate::{Specified as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
@@ -38,17 +38,14 @@ impl Mode {
 
         for item in the_trait.items.into_iter() {
             match item {
-                TraitItem::Fn(func) => {
+                TraitItem::Fn(mut func) => {
                     // NOTE: We have no way of knowing which attributes are
                     //   "external" - meant for the interface and belong on the wrapper,
                     //   "internal" - meant for the mangled implementation.
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
 
-                    let SpecTraitItemFn {
-                        spec: fn_spec,
-                        node: mut func,
-                    } = func.with_spec_from_attrs()?;
+                    let fn_spec = func.with_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -213,7 +210,7 @@ impl Mode {
 
         for item in the_impl.items.into_iter() {
             match item {
-                ImplItem::Fn(func) => {
+                ImplItem::Fn(mut func) => {
                     if func.sig.ident.to_string().starts_with("__anodized_") {
                         return Err(syn::Error::new_spanned(
                             func.sig.ident,
@@ -222,10 +219,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let SpecImplItemFn {
-                        spec: fn_spec,
-                        node: mut func,
-                    } = func.with_spec_from_attrs()?;
+                    let fn_spec = func.with_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -12,7 +12,7 @@ use syn::{
 use crate::{
     DataSpec, Spec,
     annotate::{get_attr_input, remove_spec_attr},
-    instrument::{Mode, find_spec_attr, make_item_error},
+    instrument::{Mode, make_item_error},
 };
 
 impl Mode {
@@ -163,27 +163,21 @@ impl Mode {
                     new_trait_items.push(TraitItem::Fn(func));
                 }
                 TraitItem::Const(mut const_item) => {
-                    let (spec, attrs) = find_spec_attr(const_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait const"));
                     }
-                    const_item.attrs = attrs;
                     new_trait_items.push(TraitItem::Const(const_item));
                 }
                 TraitItem::Type(mut type_item) => {
-                    let (spec, attrs) = find_spec_attr(type_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait type"));
                     }
-                    type_item.attrs = attrs;
                     new_trait_items.push(TraitItem::Type(type_item));
                 }
                 TraitItem::Macro(mut macro_item) => {
-                    let (spec, attrs) = find_spec_attr(macro_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait macro"));
                     }
-                    macro_item.attrs = attrs;
                     new_trait_items.push(TraitItem::Macro(macro_item));
                 }
                 TraitItem::Verbatim(token_stream) => {
@@ -317,27 +311,21 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     new_items.push(ImplItem::Fn(func));
                 }
                 ImplItem::Const(mut const_item) => {
-                    let (spec, attrs) = find_spec_attr(const_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl const"));
                     }
-                    const_item.attrs = attrs;
                     new_items.push(ImplItem::Const(const_item));
                 }
                 ImplItem::Type(mut type_item) => {
-                    let (spec, attrs) = find_spec_attr(type_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl type"));
                     }
-                    type_item.attrs = attrs;
                     new_items.push(ImplItem::Type(type_item));
                 }
                 ImplItem::Macro(mut macro_item) => {
-                    let (spec, attrs) = find_spec_attr(macro_item.attrs)?;
-                    if let Some(ref spec_attr) = spec {
+                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl macro"));
                     }
-                    macro_item.attrs = attrs;
                     new_items.push(ImplItem::Macro(macro_item));
                 }
                 ImplItem::Verbatim(token_stream) => {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -10,7 +10,7 @@ use syn::{
 
 use crate::{
     DataSpec,
-    annotate::{Specified as _, remove_spec_attr},
+    annotate::{Specified as _, syntax::remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -11,7 +11,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn, SpecTraitItemFn,
-    annotate::{get_attr_input, remove_spec_attr},
+    annotate::{ParseOnItem as _, get_attr_input, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -48,7 +48,7 @@ impl Mode {
                     let SpecTraitItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = func.parse_spec_attr()?;
+                    } = func.with_spec_attr()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -225,7 +225,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     let SpecImplItemFn {
                         spec: fn_spec,
                         item: mut func,
-                    } = func.parse_spec_attr()?;
+                    } = func.with_spec_attr()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -45,7 +45,7 @@ impl Mode {
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
 
-                    let fn_spec = func.with_spec_from_attrs()?;
+                    let fn_spec = func.parse_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -219,7 +219,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let fn_spec = func.with_spec_from_attrs()?;
+                    let fn_spec = func.parse_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -2,6 +2,7 @@
 #[path = "traits_tests.rs"]
 mod traits_tests;
 
+use proc_macro2::TokenStream;
 use syn::{
     Attribute, Block, FnArg, ImplItem, ImplItemFn, Pat, PatConst, PatIdent, PatLit, PatParen,
     PatPath, PatRange, PatSlice, PatStruct, PatTuple, PatTupleStruct, ReturnType, TraitItem,
@@ -10,6 +11,7 @@ use syn::{
 
 use crate::{
     DataSpec, Spec,
+    annotate::get_attr_input,
     instrument::{Mode, find_spec_attr, make_item_error},
 };
 
@@ -46,10 +48,11 @@ impl Mode {
                     //   Right now we put all attribs on both functions, but that's certainly
                     //   not going to work in every situation.
 
-                    let fn_spec: Spec = match spec_attr {
-                        Some(spec_attr) => spec_attr.parse_args()?,
-                        None => Spec::empty(),
+                    let spec_input = match spec_attr {
+                        Some(spec_attr) => get_attr_input(spec_attr)?,
+                        None => TokenStream::new(),
                     };
+                    let fn_spec: Spec = syn::parse2(spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -232,10 +235,11 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                         ));
                     }
 
-                    let fn_spec: Spec = match spec_attr {
-                        Some(spec_attr) => spec_attr.parse_args()?,
-                        None => Spec::empty(),
+                    let spec_input = match spec_attr {
+                        Some(spec_attr) => get_attr_input(spec_attr)?,
+                        None => TokenStream::new(),
                     };
+                    let fn_spec: Spec = syn::parse2(spec_input)?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -10,7 +10,7 @@ use syn::{
 
 use crate::{
     DataSpec, SpecImplItemFn, SpecTraitItemFn,
-    annotate::{Specify as _, remove_spec_attr},
+    annotate::{Specified as _, remove_spec_attr},
     instrument::{Mode, make_item_error},
 };
 
@@ -47,8 +47,8 @@ impl Mode {
 
                     let SpecTraitItemFn {
                         spec: fn_spec,
-                        item: mut func,
-                    } = func.with_spec_attr()?;
+                        node: mut func,
+                    } = func.with_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),
@@ -224,8 +224,8 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
 
                     let SpecImplItemFn {
                         spec: fn_spec,
-                        item: mut func,
-                    } = func.with_spec_attr()?;
+                        node: mut func,
+                    } = func.with_spec_from_attrs()?;
 
                     let attrs: [Attribute; 2] = [
                         parse_quote!(#[doc(hidden)]),

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -1,13 +1,17 @@
-use crate::{instrument::CheckSettings, qualifiers::FnQualifiers, test_util::assert_tokens_eq};
+use crate::{
+    instrument::CheckSettings,
+    qualifiers::FnQualifiers,
+    test_util::{SpecItemImpl, SpecItemTrait, assert_tokens_eq},
+};
 
 use super::*;
 use proc_macro2::TokenStream;
-use syn::{ItemImpl, ItemTrait, parse_quote};
+use syn::parse_quote;
 
 #[test]
 fn embed_spec_item_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_trait: ItemTrait = parse_quote! {
+    let spec_item_trait: SpecItemTrait = parse_quote! {
+        #[spec]
         trait TRAIT {
             #[spec(
                 requires: COND_1,
@@ -55,15 +59,15 @@ fn embed_spec_item_trait() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_trait(trait_spec, item_trait)
+        .instrument_item_trait(spec_item_trait.spec, spec_item_trait.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn default_instrument_item_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_trait: ItemTrait = parse_quote! {
+    let spec_item_trait: SpecItemTrait = parse_quote! {
+        #[spec]
         trait TRAIT {
             #[spec(
                 requires: COND_1,
@@ -111,15 +115,15 @@ fn default_instrument_item_trait() {
     };
 
     let observed = Mode::DEFAULT
-        .instrument_item_trait(trait_spec, item_trait)
+        .instrument_item_trait(spec_item_trait.spec, spec_item_trait.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn emit_try_fn_instrument_item_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_trait: ItemTrait = parse_quote! {
+    let spec_item_trait: SpecItemTrait = parse_quote! {
+        #[spec]
         trait TRAIT {
             #[spec(
                 requires: COND_1,
@@ -191,15 +195,15 @@ fn emit_try_fn_instrument_item_trait() {
     };
 
     let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
-        .instrument_item_trait(trait_spec, item_trait)
+        .instrument_item_trait(spec_item_trait.spec, spec_item_trait.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn embed_spec_item_impl_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl TRAIT for IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -243,15 +247,15 @@ fn embed_spec_item_impl_trait() {
     };
 
     let observed = Mode::EmbedSpecs
-        .instrument_item_trait_impl(trait_spec, item_impl)
+        .instrument_item_trait_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn default_instrument_item_impl_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl TRAIT for IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -299,15 +303,15 @@ fn default_instrument_item_impl_trait() {
     };
 
     let observed = Mode::DEFAULT
-        .instrument_item_trait_impl(trait_spec, item_impl)
+        .instrument_item_trait_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }
 
 #[test]
 fn emit_try_fn_instrument_item_impl_trait() {
-    let trait_spec = DataSpec::empty();
-    let item_impl: ItemImpl = parse_quote! {
+    let spec_item_impl: SpecItemImpl = parse_quote! {
+        #[spec]
         impl TRAIT for IMPL_TYPE {
             #[spec(
                 requires: COND_1,
@@ -363,7 +367,7 @@ fn emit_try_fn_instrument_item_impl_trait() {
     };
 
     let observed = Mode::InjectChecks(CheckSettings::PRINT_AND_TRY)
-        .instrument_item_trait_impl(trait_spec, item_impl)
+        .instrument_item_trait_impl(spec_item_impl.spec, spec_item_impl.node)
         .unwrap();
     assert_tokens_eq(&observed, &expected);
 }

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro2::Span;
-use syn::{Error, Expr, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta, Pat, TraitItemFn};
+use syn::{Error, Expr, Meta, Pat};
 
 use crate::qualifiers::FnQualifiers;
 
@@ -11,27 +11,6 @@ pub mod qualifiers;
 
 #[cfg(test)]
 mod test_util;
-
-/// Specified `fn`.
-pub type SpecItemFn = NodeWithSpec<FnSpec, ItemFn>;
-
-/// Specified `fn` inside an `impl`.
-pub type SpecImplItemFn = NodeWithSpec<FnSpec, ImplItemFn>;
-
-/// Specified `fn` inside a `trait`.
-pub type SpecTraitItemFn = NodeWithSpec<FnSpec, TraitItemFn>;
-
-/// Specified `struct`.
-pub type SpecItemStruct = NodeWithSpec<DataSpec, ItemStruct>;
-
-/// Specified `enum`.
-pub type SpecItemEnum = NodeWithSpec<DataSpec, ItemEnum>;
-
-/// An AST node with a spec attached.
-pub struct NodeWithSpec<Spec, AstNode> {
-    pub spec: Spec,
-    pub node: AstNode,
-}
 
 /// Specifies the intended behavior of a function or method: `fn`.
 #[derive(Debug)]

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -13,33 +13,23 @@ pub mod qualifiers;
 mod test_util;
 
 /// Specified `fn`.
-pub struct SpecItemFn {
-    pub spec: FnSpec,
-    pub item: ItemFn,
-}
+pub type SpecItemFn = SpecItem<FnSpec, ItemFn>;
 
 /// Specified `fn` inside an `impl`.
-pub struct SpecImplItemFn {
-    pub spec: FnSpec,
-    pub item: ImplItemFn,
-}
+pub type SpecImplItemFn = SpecItem<FnSpec, ImplItemFn>;
 
 /// Specified `fn` inside a `trait`.
-pub struct SpecTraitItemFn {
-    pub spec: FnSpec,
-    pub item: TraitItemFn,
-}
+pub type SpecTraitItemFn = SpecItem<FnSpec, TraitItemFn>;
 
 /// Specified `struct`.
-pub struct SpecItemStruct {
-    pub spec: DataSpec,
-    pub item: ItemStruct,
-}
+pub type SpecItemStruct = SpecItem<DataSpec, ItemStruct>;
 
 /// Specified `enum`.
-pub struct SpecItemEnum {
-    pub spec: DataSpec,
-    pub item: ItemEnum,
+pub type SpecItemEnum = SpecItem<DataSpec, ItemEnum>;
+
+pub struct SpecItem<Spec, Item> {
+    pub spec: Spec,
+    pub item: Item,
 }
 
 /// Specifies the intended behavior of a function or method: `fn`.

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -13,23 +13,24 @@ pub mod qualifiers;
 mod test_util;
 
 /// Specified `fn`.
-pub type SpecItemFn = SpecItem<FnSpec, ItemFn>;
+pub type SpecItemFn = NodeWithSpec<FnSpec, ItemFn>;
 
 /// Specified `fn` inside an `impl`.
-pub type SpecImplItemFn = SpecItem<FnSpec, ImplItemFn>;
+pub type SpecImplItemFn = NodeWithSpec<FnSpec, ImplItemFn>;
 
 /// Specified `fn` inside a `trait`.
-pub type SpecTraitItemFn = SpecItem<FnSpec, TraitItemFn>;
+pub type SpecTraitItemFn = NodeWithSpec<FnSpec, TraitItemFn>;
 
 /// Specified `struct`.
-pub type SpecItemStruct = SpecItem<DataSpec, ItemStruct>;
+pub type SpecItemStruct = NodeWithSpec<DataSpec, ItemStruct>;
 
 /// Specified `enum`.
-pub type SpecItemEnum = SpecItem<DataSpec, ItemEnum>;
+pub type SpecItemEnum = NodeWithSpec<DataSpec, ItemEnum>;
 
-pub struct SpecItem<Spec, Item> {
+/// An AST node with a spec attached.
+pub struct NodeWithSpec<Spec, AstNode> {
     pub spec: Spec,
-    pub item: Item,
+    pub node: AstNode,
 }
 
 /// Specifies the intended behavior of a function or method: `fn`.

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -14,19 +14,19 @@ mod test_util;
 
 /// Specified `fn`.
 pub struct SpecItemFn {
-    pub spec: Spec,
+    pub spec: FnSpec,
     pub item: ItemFn,
 }
 
 /// Specified `fn` inside an `impl`.
 pub struct SpecImplItemFn {
-    pub spec: Spec,
+    pub spec: FnSpec,
     pub item: ImplItemFn,
 }
 
 /// Specified `fn` inside a `trait`.
 pub struct SpecTraitItemFn {
-    pub spec: Spec,
+    pub spec: FnSpec,
     pub item: TraitItemFn,
 }
 
@@ -44,8 +44,7 @@ pub struct SpecItemEnum {
 
 /// Specifies the intended behavior of a function or method: `fn`.
 #[derive(Debug)]
-// TODO: Rename to `FnSpec` to reduce ambiguity.
-pub struct Spec {
+pub struct FnSpec {
     /// Qualifiers that constrain the behavior of the computation.
     pub qualifiers: FnQualifiers,
     /// Preconditions: conditions that must hold when the function is called.
@@ -60,7 +59,7 @@ pub struct Spec {
     span: Span,
 }
 
-impl Spec {
+impl FnSpec {
     /// Empty spec that contains no elements.
     pub fn empty() -> Self {
         Self {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -30,18 +30,6 @@ pub struct FnSpec {
 }
 
 impl FnSpec {
-    /// Empty spec that contains no elements.
-    pub fn empty() -> Self {
-        Self {
-            qualifiers: FnQualifiers::empty(),
-            requires: vec![],
-            maintains: vec![],
-            captures: vec![],
-            ensures: vec![],
-            span: Span::call_site(),
-        }
-    }
-
     /// Returns `true` if the spec is empty (specifies nothing), otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         self.qualifiers.is_empty()
@@ -67,14 +55,6 @@ pub struct DataSpec {
 }
 
 impl DataSpec {
-    /// Empty spec that contains no elements.
-    pub fn empty() -> Self {
-        Self {
-            maintains: vec![],
-            span: Span::call_site(),
-        }
-    }
-
     /// Returns `true` if the spec is empty (specifies nothing), otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         self.maintains.is_empty()

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro2::Span;
-use syn::{Error, Expr, Meta, Pat};
+use syn::{Error, Expr, ImplItemFn, ItemEnum, ItemFn, ItemStruct, Meta, Pat, TraitItemFn};
 
 use crate::qualifiers::FnQualifiers;
 
@@ -11,6 +11,36 @@ pub mod qualifiers;
 
 #[cfg(test)]
 mod test_util;
+
+/// Specified `fn`.
+pub struct SpecItemFn {
+    pub spec: Spec,
+    pub item: ItemFn,
+}
+
+/// Specified `fn` inside an `impl`.
+pub struct SpecImplItemFn {
+    pub spec: Spec,
+    pub item: ImplItemFn,
+}
+
+/// Specified `fn` inside a `trait`.
+pub struct SpecTraitItemFn {
+    pub spec: Spec,
+    pub item: TraitItemFn,
+}
+
+/// Specified `struct`.
+pub struct SpecItemStruct {
+    pub spec: DataSpec,
+    pub item: ItemStruct,
+}
+
+/// Specified `enum`.
+pub struct SpecEnumItem {
+    pub spec: DataSpec,
+    pub item: ItemEnum,
+}
 
 /// Specifies the intended behavior of a function or method: `fn`.
 #[derive(Debug)]

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -37,7 +37,7 @@ pub struct SpecItemStruct {
 }
 
 /// Specified `enum`.
-pub struct SpecEnumItem {
+pub struct SpecItemEnum {
     pub spec: DataSpec,
     pub item: ItemEnum,
 }

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,4 +1,4 @@
-use crate::{Capture, Condition, PostCondition, Spec, instrument::patterns::TamePat};
+use crate::{Capture, Condition, FnSpec, PostCondition, instrument::patterns::TamePat};
 use pretty_assertions::assert_eq;
 use quote::{ToTokens, quote};
 
@@ -21,9 +21,9 @@ fn pretty_print_tokens(ts: proc_macro2::TokenStream) -> String {
     prettyplease::unparse(&file)
 }
 
-pub fn assert_spec_eq(left: &Spec, right: &Spec) {
+pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
     // Destructure to ensure we handle all fields - compilation will fail if fields are added
-    let Spec {
+    let FnSpec {
         qualifiers: left_qualifiers,
         requires: left_requires,
         maintains: left_maintains,
@@ -32,7 +32,7 @@ pub fn assert_spec_eq(left: &Spec, right: &Spec) {
         span: _,
     } = left;
 
-    let Spec {
+    let FnSpec {
         qualifiers: right_qualifiers,
         requires: right_requires,
         maintains: right_maintains,

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,6 +1,42 @@
-use crate::{Capture, Condition, FnSpec, PostCondition, instrument::patterns::TamePat};
+use crate::{
+    Capture, Condition, DataSpec, FnSpec, PostCondition, annotate::Specified,
+    instrument::patterns::TamePat,
+};
 use pretty_assertions::assert_eq;
 use quote::{ToTokens, quote};
+use syn::{
+    ImplItemFn, ItemEnum, ItemFn, ItemStruct, TraitItemFn,
+    parse::{Parse, ParseStream},
+};
+
+/// Specified `fn`.
+pub type SpecItemFn = NodeWithSpec<FnSpec, ItemFn>;
+
+/// Specified `fn` inside an `impl`.
+pub type SpecImplItemFn = NodeWithSpec<FnSpec, ImplItemFn>;
+
+/// Specified `fn` inside a `trait`.
+pub type SpecTraitItemFn = NodeWithSpec<FnSpec, TraitItemFn>;
+
+/// Specified `struct`.
+pub type SpecItemStruct = NodeWithSpec<DataSpec, ItemStruct>;
+
+/// Specified `enum`.
+pub type SpecItemEnum = NodeWithSpec<DataSpec, ItemEnum>;
+
+/// An AST node with a spec attached.
+pub struct NodeWithSpec<Spec, AstNode> {
+    pub spec: Spec,
+    pub node: AstNode,
+}
+
+impl<AstNode: Parse + Specified> Parse for NodeWithSpec<AstNode::Spec, AstNode> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut node: AstNode = input.parse()?;
+        let spec = node.parse_spec_from_attrs()?;
+        Ok(Self { spec, node })
+    }
+}
 
 pub fn assert_tokens_eq(left: &impl ToTokens, right: &impl ToTokens) {
     let left_str = pretty_print_tokens(left.to_token_stream());

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -4,25 +4,22 @@ use crate::{
 };
 use pretty_assertions::assert_eq;
 use quote::{ToTokens, quote};
-use syn::{
-    ImplItemFn, ItemEnum, ItemFn, ItemStruct, TraitItemFn,
-    parse::{Parse, ParseStream},
-};
+use syn::parse::{Parse, ParseStream};
 
 /// Specified `fn`.
-pub type SpecItemFn = NodeWithSpec<FnSpec, ItemFn>;
+pub type SpecItemFn = NodeWithSpec<FnSpec, syn::ItemFn>;
 
-/// Specified `fn` inside an `impl`.
-pub type SpecImplItemFn = NodeWithSpec<FnSpec, ImplItemFn>;
+/// Specified `impl`.
+pub type SpecItemImpl = NodeWithSpec<DataSpec, syn::ItemImpl>;
 
-/// Specified `fn` inside a `trait`.
-pub type SpecTraitItemFn = NodeWithSpec<FnSpec, TraitItemFn>;
+/// Specified `trait`.
+pub type SpecItemTrait = NodeWithSpec<DataSpec, syn::ItemTrait>;
 
 /// Specified `struct`.
-pub type SpecItemStruct = NodeWithSpec<DataSpec, ItemStruct>;
+pub type SpecItemStruct = NodeWithSpec<DataSpec, syn::ItemStruct>;
 
 /// Specified `enum`.
-pub type SpecItemEnum = NodeWithSpec<DataSpec, ItemEnum>;
+pub type SpecItemEnum = NodeWithSpec<DataSpec, syn::ItemEnum>;
 
 /// An AST node with a spec attached.
 pub struct NodeWithSpec<Spec, AstNode> {

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,7 +6,7 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    annotate::{Specify as _, syntax::SpecFields},
+    annotate::{Specified as _, syntax::SpecFields},
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
 
@@ -40,22 +40,22 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let result = match item {
         Item::Fn(func) => func
-            .with_spec_parse(spec_fields)
+            .with_spec_from_fields(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
         Item::Trait(the_trait) => the_trait
-            .with_spec_parse(spec_fields)
+            .with_spec_from_fields(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_trait(spec_item.spec, spec_item.item)),
-        Item::Impl(the_impl) if the_impl.trait_.is_some() => {
-            the_impl.with_spec_parse(spec_fields).and_then(|spec_item| {
+        Item::Impl(the_impl) if the_impl.trait_.is_some() => the_impl
+            .with_spec_from_fields(spec_fields)
+            .and_then(|spec_item| {
                 CONFIG.instrument_item_trait_impl(spec_item.spec, spec_item.item)
-            })
-        }
+            }),
         Item::Impl(the_impl) if the_impl.trait_.is_none() => the_impl
-            .with_spec_parse(spec_fields)
+            .with_spec_from_fields(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_impl(spec_item.spec, spec_item.item)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
         Item::Enum(the_enum) => the_enum
-            .with_spec_parse(spec_fields)
+            .with_spec_from_fields(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_enum(spec_item.spec, spec_item.item)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
@@ -63,7 +63,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
         Item::Struct(the_struct) => the_struct
-            .with_spec_parse(spec_fields)
+            .with_spec_from_fields(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_struct(spec_item.spec, spec_item.item)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,7 +6,7 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    DataSpec, Spec,
+    DataSpec, SpecItemFn,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
 
@@ -36,10 +36,8 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
-        Item::Fn(func) => {
-            let spec = parse_macro_input!(args as Spec);
-            CONFIG.instrument_item_fn(spec, func)
-        }
+        Item::Fn(func) => SpecItemFn::parse_spec_on(func, args.into())
+            .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
         Item::Trait(the_trait) => {
             let spec = parse_macro_input!(args as DataSpec);
             CONFIG.instrument_item_trait(spec, the_trait)

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,7 +6,6 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    DataSpec,
     annotate::Specify as _,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
@@ -40,32 +39,29 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Fn(func) => func
             .parse_spec(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
-        Item::Trait(the_trait) => {
-            let spec = parse_macro_input!(args as DataSpec);
-            CONFIG.instrument_item_trait(spec, the_trait)
-        }
+        Item::Trait(the_trait) => the_trait
+            .parse_spec(args.into())
+            .and_then(|spec_item| CONFIG.instrument_item_trait(spec_item.spec, spec_item.item)),
         Item::Impl(the_impl) if the_impl.trait_.is_some() => {
-            let spec = parse_macro_input!(args as DataSpec);
-            CONFIG.instrument_item_trait_impl(spec, the_impl)
+            the_impl.parse_spec(args.into()).and_then(|spec_item| {
+                CONFIG.instrument_item_trait_impl(spec_item.spec, spec_item.item)
+            })
         }
-        Item::Impl(the_impl) if the_impl.trait_.is_none() => {
-            let spec = parse_macro_input!(args as DataSpec);
-            CONFIG.instrument_item_impl(spec, the_impl)
-        }
+        Item::Impl(the_impl) if the_impl.trait_.is_none() => the_impl
+            .parse_spec(args.into())
+            .and_then(|spec_item| CONFIG.instrument_item_impl(spec_item.spec, spec_item.item)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
-        Item::Enum(the_enum) => {
-            let spec = parse_macro_input!(args as DataSpec);
-            CONFIG.instrument_item_enum(spec, the_enum)
-        }
+        Item::Enum(the_enum) => the_enum
+            .parse_spec(args.into())
+            .and_then(|spec_item| CONFIG.instrument_item_enum(spec_item.spec, spec_item.item)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
         Item::Macro(_) => Err(make_item_error(&item, "macro")),
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
-        Item::Struct(the_struct) => {
-            let spec = parse_macro_input!(args as DataSpec);
-            CONFIG.instrument_item_struct(spec, the_struct)
-        }
+        Item::Struct(the_struct) => the_struct
+            .parse_spec(args.into())
+            .and_then(|spec_item| CONFIG.instrument_item_struct(spec_item.spec, spec_item.item)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),
         Item::Union(_) => Err(make_item_error(&item, "union")),

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,7 +6,7 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    annotate::Specify as _,
+    annotate::{Specify as _, syntax::SpecFields},
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
 
@@ -32,27 +32,30 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
 /// - runtime checks: for supported items, configured by `cfg` settings
 #[proc_macro_attribute]
 pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the `#[spec]` attribute's arguments.
+    let spec_fields = parse_macro_input!(args as SpecFields);
+
     // Parse the item to which the attribute is attached.
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
         Item::Fn(func) => func
-            .with_spec_parse(args.into())
+            .with_spec_parse(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
         Item::Trait(the_trait) => the_trait
-            .with_spec_parse(args.into())
+            .with_spec_parse(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_trait(spec_item.spec, spec_item.item)),
         Item::Impl(the_impl) if the_impl.trait_.is_some() => {
-            the_impl.with_spec_parse(args.into()).and_then(|spec_item| {
+            the_impl.with_spec_parse(spec_fields).and_then(|spec_item| {
                 CONFIG.instrument_item_trait_impl(spec_item.spec, spec_item.item)
             })
         }
         Item::Impl(the_impl) if the_impl.trait_.is_none() => the_impl
-            .with_spec_parse(args.into())
+            .with_spec_parse(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_impl(spec_item.spec, spec_item.item)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
         Item::Enum(the_enum) => the_enum
-            .with_spec_parse(args.into())
+            .with_spec_parse(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_enum(spec_item.spec, spec_item.item)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
@@ -60,7 +63,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
         Item::Struct(the_struct) => the_struct
-            .with_spec_parse(args.into())
+            .with_spec_parse(spec_fields)
             .and_then(|spec_item| CONFIG.instrument_item_struct(spec_item.spec, spec_item.item)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,8 +6,8 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    DataSpec, SpecItemFn,
-    annotate::ParseOnItem as _,
+    DataSpec,
+    annotate::Specify as _,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
 
@@ -37,7 +37,8 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
-        Item::Fn(func) => SpecItemFn::parse_spec_on(func, args.into())
+        Item::Fn(func) => func
+            .parse_spec(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
         Item::Trait(the_trait) => {
             let spec = parse_macro_input!(args as DataSpec);

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -7,6 +7,7 @@ use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
     DataSpec, SpecItemFn,
+    annotate::ParseOnItem as _,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
 };
 

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -40,20 +40,20 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let result = match item {
         Item::Fn(mut func) => func
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_fn(spec, func)),
         Item::Trait(mut the_trait) => the_trait
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_trait(spec, the_trait)),
         Item::Impl(mut the_impl) if the_impl.trait_.is_some() => the_impl
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_trait_impl(spec, the_impl)),
         Item::Impl(mut the_impl) if the_impl.trait_.is_none() => the_impl
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_impl(spec, the_impl)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
         Item::Enum(mut the_enum) => the_enum
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_enum(spec, the_enum)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
@@ -61,7 +61,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
         Item::Struct(mut the_struct) => the_struct
-            .with_spec_from_fields(spec_fields)
+            .parse_spec_from_fields(spec_fields)
             .and_then(|spec| CONFIG.instrument_item_struct(spec, the_struct)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -37,22 +37,22 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let result = match item {
         Item::Fn(func) => func
-            .parse_spec(args.into())
+            .with_spec_parse(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
         Item::Trait(the_trait) => the_trait
-            .parse_spec(args.into())
+            .with_spec_parse(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_trait(spec_item.spec, spec_item.item)),
         Item::Impl(the_impl) if the_impl.trait_.is_some() => {
-            the_impl.parse_spec(args.into()).and_then(|spec_item| {
+            the_impl.with_spec_parse(args.into()).and_then(|spec_item| {
                 CONFIG.instrument_item_trait_impl(spec_item.spec, spec_item.item)
             })
         }
         Item::Impl(the_impl) if the_impl.trait_.is_none() => the_impl
-            .parse_spec(args.into())
+            .with_spec_parse(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_impl(spec_item.spec, spec_item.item)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
         Item::Enum(the_enum) => the_enum
-            .parse_spec(args.into())
+            .with_spec_parse(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_enum(spec_item.spec, spec_item.item)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
@@ -60,7 +60,7 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
         Item::Struct(the_struct) => the_struct
-            .parse_spec(args.into())
+            .with_spec_parse(args.into())
             .and_then(|spec_item| CONFIG.instrument_item_struct(spec_item.spec, spec_item.item)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -39,32 +39,30 @@ pub fn spec(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let result = match item {
-        Item::Fn(func) => func
+        Item::Fn(mut func) => func
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| CONFIG.instrument_item_fn(spec_item.spec, spec_item.item)),
-        Item::Trait(the_trait) => the_trait
+            .and_then(|spec| CONFIG.instrument_item_fn(spec, func)),
+        Item::Trait(mut the_trait) => the_trait
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| CONFIG.instrument_item_trait(spec_item.spec, spec_item.item)),
-        Item::Impl(the_impl) if the_impl.trait_.is_some() => the_impl
+            .and_then(|spec| CONFIG.instrument_item_trait(spec, the_trait)),
+        Item::Impl(mut the_impl) if the_impl.trait_.is_some() => the_impl
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| {
-                CONFIG.instrument_item_trait_impl(spec_item.spec, spec_item.item)
-            }),
-        Item::Impl(the_impl) if the_impl.trait_.is_none() => the_impl
+            .and_then(|spec| CONFIG.instrument_item_trait_impl(spec, the_impl)),
+        Item::Impl(mut the_impl) if the_impl.trait_.is_none() => the_impl
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| CONFIG.instrument_item_impl(spec_item.spec, spec_item.item)),
+            .and_then(|spec| CONFIG.instrument_item_impl(spec, the_impl)),
         Item::Const(_) => Err(make_item_error(&item, "const")),
-        Item::Enum(the_enum) => the_enum
+        Item::Enum(mut the_enum) => the_enum
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| CONFIG.instrument_item_enum(spec_item.spec, spec_item.item)),
+            .and_then(|spec| CONFIG.instrument_item_enum(spec, the_enum)),
         Item::ExternCrate(_) => Err(make_item_error(&item, "extern crate")),
         Item::ForeignMod(_) => Err(make_item_error(&item, "extern block")),
         Item::Macro(_) => Err(make_item_error(&item, "macro")),
         Item::Mod(_) => Err(make_item_error(&item, "mod")),
         Item::Static(_) => Err(make_item_error(&item, "static")),
-        Item::Struct(the_struct) => the_struct
+        Item::Struct(mut the_struct) => the_struct
             .with_spec_from_fields(spec_fields)
-            .and_then(|spec_item| CONFIG.instrument_item_struct(spec_item.spec, spec_item.item)),
+            .and_then(|spec| CONFIG.instrument_item_struct(spec, the_struct)),
         Item::TraitAlias(_) => Err(make_item_error(&item, "trait alias")),
         Item::Type(_) => Err(make_item_error(&item, "type")),
         Item::Union(_) => Err(make_item_error(&item, "union")),


### PR DESCRIPTION
- Rename `Spec` to `FnSpec` and convert typed specs from raw `SpecFields` with `TryFrom`.
- Introduce `Specified` for supported items and loop expressions to parse specs in AST context.
- Update instrumentation to use context-aware spec parsing and centralized attribute helpers.
- Refactor loop instrumentation to read `#[spec]` directly from `while` and `for` expressions.
- Update core test fixtures to parse annotated nodes together with their associated specs.