### PR TITLE
feat: `#[unspec]` attribute

### DIFF
--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, EmptySpec, FnSpec, InputSpec, LoopSpec, LoopVariant,
+    Capture, Condition, DataSpec, EmptySpec, FnSpec, InputSpecFlags, LoopSpec, LoopVariant,
     PostCondition,
     qualifiers::FnQualifiers,
     syntax::{
@@ -183,7 +183,7 @@ impl FnSpec {
     fn extract_unspec_info(
         inputs: &mut Punctuated<FnArg, Token![,]>,
         attrs: &mut Vec<Attribute>,
-    ) -> Result<(Vec<InputSpec>, bool)> {
+    ) -> Result<(Vec<InputSpecFlags>, bool)> {
         let mut input_specs = Vec::with_capacity(inputs.len());
 
         for input in inputs {
@@ -195,21 +195,21 @@ impl FnSpec {
             let input_spec = if let Some(attr) = remove_unique_attr("unspec", attrs)? {
                 let unspec: UnspecAttr = attr.try_into()?;
                 match unspec.arg {
-                    None => InputSpec {
+                    None => InputSpecFlags {
                         on_entry: false,
                         on_exit: false,
                     },
-                    Some((_, UnspecArg::In(_))) => InputSpec {
+                    Some((_, UnspecArg::In(_))) => InputSpecFlags {
                         on_entry: false,
                         on_exit: true,
                     },
-                    Some((_, UnspecArg::Out(_))) => InputSpec {
+                    Some((_, UnspecArg::Out(_))) => InputSpecFlags {
                         on_entry: true,
                         on_exit: false,
                     },
                 }
             } else {
-                InputSpec::default()
+                InputSpecFlags::default()
             };
             input_specs.push(input_spec);
         }
@@ -234,7 +234,7 @@ impl FnSpec {
 
     fn from_spec_and_unspec_info(
         raw_spec: SpecFields,
-        input_specs: Vec<InputSpec>,
+        input_specs: Vec<InputSpecFlags>,
         output_spec_on_exit: bool,
     ) -> Result<FnSpec> {
         let span = raw_spec.span();
@@ -358,8 +358,8 @@ impl FnSpec {
 
         Ok(Self {
             qualifiers,
-            input_specs,
-            output_spec_on_exit,
+            input_spec_flags: input_specs,
+            output_spec_flag: output_spec_on_exit,
             requires,
             maintains,
             captures,
@@ -438,7 +438,7 @@ impl DataSpec {
         }
 
         Ok(Self {
-            field_specs,
+            field_spec_flags: field_specs,
             maintains,
             span,
         })

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -6,7 +6,8 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, EmptySpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
+    Capture, Condition, DataSpec, EmptySpec, FnSpec, InputSpec, LoopSpec, LoopVariant,
+    PostCondition,
     qualifiers::FnQualifiers,
     syntax::{
         attr::{get_attr_input, remove_unique_attr},
@@ -59,7 +60,7 @@ impl Specified for ItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
+        FnSpec::from_spec_and_fn(fields, self)
     }
 }
 
@@ -71,7 +72,7 @@ impl Specified for ImplItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
+        FnSpec::from_spec_and_impl_fn(fields, self)
     }
 }
 
@@ -83,7 +84,7 @@ impl Specified for TraitItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
+        FnSpec::from_spec_and_trait_fn(fields, self)
     }
 }
 
@@ -119,7 +120,7 @@ impl Specified for ItemStruct {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
+        DataSpec::from_spec_and_struct(fields, self)
     }
 }
 
@@ -131,7 +132,7 @@ impl Specified for ItemEnum {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        fields.try_into()
+        DataSpec::from_spec_and_enum(fields, self)
     }
 }
 
@@ -159,10 +160,33 @@ impl Specified for ExprWhile {
     }
 }
 
-impl TryFrom<SpecFields> for FnSpec {
-    type Error = Error;
+impl FnSpec {
+    pub fn from_spec_and_fn(raw_spec: SpecFields, item_fn: &mut ItemFn) -> Result<Self> {
+        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
+        let input_specs = vec![];
+        let output_spec_on_exit = false;
+        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
+    }
 
-    fn try_from(raw_spec: SpecFields) -> Result<FnSpec> {
+    pub fn from_spec_and_impl_fn(raw_spec: SpecFields, item_fn: &mut ImplItemFn) -> Result<Self> {
+        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
+        let input_specs = vec![];
+        let output_spec_on_exit = false;
+        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
+    }
+
+    pub fn from_spec_and_trait_fn(raw_spec: SpecFields, item_fn: &mut TraitItemFn) -> Result<Self> {
+        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
+        let input_specs = vec![];
+        let output_spec_on_exit = false;
+        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
+    }
+
+    fn from_spec_and_unspec_info(
+        raw_spec: SpecFields,
+        input_specs: Vec<InputSpec>,
+        output_spec_on_exit: bool,
+    ) -> Result<FnSpec> {
         let span = raw_spec.span();
 
         let mut errors = MultiError::empty();
@@ -284,8 +308,8 @@ impl TryFrom<SpecFields> for FnSpec {
 
         Ok(Self {
             qualifiers,
-            input_specs: vec![],
-            output_spec_on_exit: false,
+            input_specs,
+            output_spec_on_exit,
             requires,
             maintains,
             captures,
@@ -295,10 +319,26 @@ impl TryFrom<SpecFields> for FnSpec {
     }
 }
 
-impl TryFrom<SpecFields> for DataSpec {
-    type Error = Error;
+impl DataSpec {
+    pub fn from_spec_and_struct(
+        raw_spec: SpecFields,
+        item_struct: &mut ItemStruct,
+    ) -> Result<Self> {
+        // TODO: Collect `#[unspec]` attributes and populate `field_specs`.
+        let field_specs = vec![];
+        Self::from_spec_and_unspec_info(raw_spec, field_specs)
+    }
 
-    fn try_from(raw_spec: SpecFields) -> Result<Self> {
+    pub fn from_spec_and_enum(raw_spec: SpecFields, item_enum: &mut ItemEnum) -> Result<Self> {
+        // TODO: Collect `#[unspec]` attributes and populate `field_specs`.
+        let field_specs = vec![];
+        Self::from_spec_and_unspec_info(raw_spec, field_specs)
+    }
+
+    fn from_spec_and_unspec_info(
+        raw_spec: SpecFields,
+        field_specs: Vec<Vec<bool>>,
+    ) -> Result<Self> {
         let span = raw_spec.span();
 
         let mut errors = MultiError::empty();
@@ -326,7 +366,7 @@ impl TryFrom<SpecFields> for DataSpec {
         }
 
         Ok(Self {
-            field_specs: vec![],
+            field_specs,
             maintains,
             span,
         })

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -12,6 +12,7 @@ use crate::{
     syntax::{
         attr::{get_attr_input, remove_unique_attr},
         spec::{Keyword, SpecFields},
+        unspec::{UnspecArg, UnspecAttr},
     },
 };
 
@@ -183,9 +184,52 @@ impl FnSpec {
         inputs: &mut Punctuated<FnArg, Token![,]>,
         attrs: &mut Vec<Attribute>,
     ) -> Result<(Vec<InputSpec>, bool)> {
-        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
-        let input_specs = vec![];
-        let output_spec_on_exit = false;
+        let mut input_specs = Vec::with_capacity(inputs.len());
+
+        for input in inputs {
+            let attrs = match input {
+                FnArg::Receiver(receiver) => &mut receiver.attrs,
+                FnArg::Typed(pat_type) => &mut pat_type.attrs,
+            };
+
+            let input_spec = if let Some(attr) = remove_unique_attr("unspec", attrs)? {
+                let unspec: UnspecAttr = attr.try_into()?;
+                match unspec.arg {
+                    None => InputSpec {
+                        on_entry: false,
+                        on_exit: false,
+                    },
+                    Some((_, UnspecArg::In(_))) => InputSpec {
+                        on_entry: false,
+                        on_exit: true,
+                    },
+                    Some((_, UnspecArg::Out(_))) => InputSpec {
+                        on_entry: true,
+                        on_exit: false,
+                    },
+                }
+            } else {
+                InputSpec::default()
+            };
+            input_specs.push(input_spec);
+        }
+
+        let output_spec_on_exit = if let Some(attr) = remove_unique_attr("unspec", attrs)? {
+            let unspec: UnspecAttr = attr.try_into()?;
+            match unspec.arg {
+                Some((_, UnspecArg::Out(_))) => false,
+                _ => {
+                    let attr: Attribute = unspec.into();
+                    return Err(Error::new_spanned(
+                        attr,
+                        "only `#[unspec(out)]` is allowed on a `fn` output",
+                    ));
+                }
+            }
+        } else {
+            true
+        };
+
         Ok((input_specs, output_spec_on_exit))
     }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -284,6 +284,8 @@ impl TryFrom<SpecFields> for FnSpec {
 
         Ok(Self {
             qualifiers,
+            input_specs: vec![],
+            output_spec_on_exit: false,
             requires,
             maintains,
             captures,
@@ -323,7 +325,11 @@ impl TryFrom<SpecFields> for DataSpec {
             return Err(combined_error);
         }
 
-        Ok(Self { maintains, span })
+        Ok(Self {
+            field_specs: vec![],
+            maintains,
+            span,
+        })
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -9,7 +9,7 @@ use crate::{
     Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
     qualifiers::FnQualifiers,
     syntax::{
-        attr::{get_attr_input, remove_spec_attr},
+        attr::{get_attr_input, remove_unique_attr},
         spec::{Keyword, SpecFields},
     },
 };
@@ -30,11 +30,12 @@ pub trait Specified {
     /// - If there's no `#[spec]` attribute, the spec is built from an empty `SpecFields`.
     /// - Multiple `#[spec]` attributes are not allowed and cause an error.
     fn parse_spec_from_attrs(&mut self) -> Result<Self::Spec> {
-        let spec_input: TokenStream = if let Some(attr) = remove_spec_attr(self.get_attrs_mut())? {
-            get_attr_input(attr)?
-        } else {
-            TokenStream::new()
-        };
+        let spec_input: TokenStream =
+            if let Some(attr) = remove_unique_attr("spec", self.get_attrs_mut())? {
+                get_attr_input(attr)?
+            } else {
+                TokenStream::new()
+            };
         let spec_fields: SpecFields = syn::parse2(spec_input)?;
         self.parse_spec_from_fields(spec_fields)
     }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -9,11 +9,7 @@ use crate::{
     Capture, Condition, DataSpec, EmptySpec, FnSpec, InputSpecFlags, LoopSpec, LoopVariant,
     PostCondition,
     qualifiers::FnQualifiers,
-    syntax::{
-        attr::{get_attr_input, remove_unique_attr},
-        spec::{Keyword, SpecFields},
-        unspec::{UnspecArg, UnspecAttr},
-    },
+    syntax::{Keyword, SpecFields, UnspecArg, UnspecAttr, get_attr_input, remove_unique_attr},
 };
 
 #[cfg(test)]

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -381,7 +381,7 @@ impl DataSpec {
                 if unspec.arg.is_some() {
                     return Err(Error::new_spanned(
                         Attribute::from(unspec),
-                        "expected `#[unspec]` on a struct or enum field",
+                        "only `#[unspec]` is allowed on a field",
                     ));
                 }
                 Ok(false)

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -121,7 +121,8 @@ impl Specified for ItemStruct {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        DataSpec::from_spec_and_struct(fields, self)
+        let variants = std::iter::once(&mut self.fields);
+        DataSpec::from_spec_and_variants(fields, variants)
     }
 }
 
@@ -133,7 +134,8 @@ impl Specified for ItemEnum {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        DataSpec::from_spec_and_enum(fields, self)
+        let variants = self.variants.iter_mut().map(|variant| &mut variant.fields);
+        DataSpec::from_spec_and_variants(fields, variants)
     }
 }
 
@@ -361,19 +363,12 @@ impl FnSpec {
 }
 
 impl DataSpec {
-    pub fn from_spec_and_struct(
+    pub fn from_spec_and_variants<'a>(
         raw_spec: SpecFields,
-        item_struct: &mut ItemStruct,
+        variants: impl Iterator<Item = &'a mut Fields>,
     ) -> Result<Self> {
-        let field_specs = vec![Self::extract_unspec_info(&mut item_struct.fields)?];
-        Self::from_spec_and_unspec_info(raw_spec, field_specs)
-    }
-
-    pub fn from_spec_and_enum(raw_spec: SpecFields, item_enum: &mut ItemEnum) -> Result<Self> {
-        let field_specs = item_enum
-            .variants
-            .iter_mut()
-            .map(|variant| Self::extract_unspec_info(&mut variant.fields))
+        let field_specs = variants
+            .map(Self::extract_unspec_info)
             .collect::<Result<_>>()?;
         Self::from_spec_and_unspec_info(raw_spec, field_specs)
     }

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -61,7 +61,7 @@ impl Specified for ItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
+        FnSpec::from_spec_and_inputs_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -73,7 +73,7 @@ impl Specified for ImplItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
+        FnSpec::from_spec_and_inputs_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -85,7 +85,7 @@ impl Specified for TraitItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
+        FnSpec::from_spec_and_inputs_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -164,7 +164,7 @@ impl Specified for ExprWhile {
 }
 
 impl FnSpec {
-    pub fn from_spec_and_input_attrs(
+    pub fn from_spec_and_inputs_attrs(
         raw_spec: SpecFields,
         inputs: &mut Punctuated<FnArg, Token![,]>,
         attrs: &mut Vec<Attribute>,

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -61,7 +61,7 @@ impl Specified for ItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_fn(fields, self)
+        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -73,7 +73,7 @@ impl Specified for ImplItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_impl_fn(fields, self)
+        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -85,7 +85,7 @@ impl Specified for TraitItemFn {
     }
 
     fn parse_spec_from_fields(&mut self, fields: SpecFields) -> Result<Self::Spec> {
-        FnSpec::from_spec_and_trait_fn(fields, self)
+        FnSpec::from_spec_and_input_attrs(fields, &mut self.sig.inputs, &mut self.attrs)
     }
 }
 
@@ -162,21 +162,12 @@ impl Specified for ExprWhile {
 }
 
 impl FnSpec {
-    pub fn from_spec_and_fn(raw_spec: SpecFields, item_fn: &mut ItemFn) -> Result<Self> {
-        let (input_specs, output_spec_on_exit) =
-            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
-        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
-    }
-
-    pub fn from_spec_and_impl_fn(raw_spec: SpecFields, item_fn: &mut ImplItemFn) -> Result<Self> {
-        let (input_specs, output_spec_on_exit) =
-            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
-        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
-    }
-
-    pub fn from_spec_and_trait_fn(raw_spec: SpecFields, item_fn: &mut TraitItemFn) -> Result<Self> {
-        let (input_specs, output_spec_on_exit) =
-            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
+    pub fn from_spec_and_input_attrs(
+        raw_spec: SpecFields,
+        inputs: &mut Punctuated<FnArg, Token![,]>,
+        attrs: &mut Vec<Attribute>,
+    ) -> Result<Self> {
+        let (input_specs, output_spec_on_exit) = Self::extract_unspec_info(inputs, attrs)?;
         Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
     }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use syn::{
-    Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, FnArg, ImplItemFn,
-    ItemEnum, ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, Token, TraitItemFn, parse::Result,
-    parse_quote, punctuated::Punctuated, spanned::Spanned,
+    Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, Fields, FnArg,
+    ImplItemFn, ItemEnum, ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, Token, TraitItemFn,
+    parse::Result, parse_quote, punctuated::Punctuated, spanned::Spanned,
 };
 
 use crate::{
@@ -375,15 +375,37 @@ impl DataSpec {
         raw_spec: SpecFields,
         item_struct: &mut ItemStruct,
     ) -> Result<Self> {
-        // TODO: Collect `#[unspec]` attributes and populate `field_specs`.
-        let field_specs = vec![];
+        let field_specs = vec![Self::extract_unspec_info(&mut item_struct.fields)?];
         Self::from_spec_and_unspec_info(raw_spec, field_specs)
     }
 
     pub fn from_spec_and_enum(raw_spec: SpecFields, item_enum: &mut ItemEnum) -> Result<Self> {
-        // TODO: Collect `#[unspec]` attributes and populate `field_specs`.
-        let field_specs = vec![];
+        let field_specs = item_enum
+            .variants
+            .iter_mut()
+            .map(|variant| Self::extract_unspec_info(&mut variant.fields))
+            .collect::<Result<_>>()?;
         Self::from_spec_and_unspec_info(raw_spec, field_specs)
+    }
+
+    fn extract_unspec_info(fields: &mut Fields) -> Result<Vec<bool>> {
+        fields
+            .iter_mut()
+            .map(|field| {
+                let Some(attr) = remove_unique_attr("unspec", &mut field.attrs)? else {
+                    return Ok(true);
+                };
+
+                let unspec: UnspecAttr = attr.try_into()?;
+                if unspec.arg.is_some() {
+                    return Err(Error::new_spanned(
+                        Attribute::from(unspec),
+                        "expected `#[unspec]` on a struct or enum field",
+                    ));
+                }
+                Ok(false)
+            })
+            .collect()
     }
 
     fn from_spec_and_unspec_info(

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -215,13 +215,12 @@ impl FnSpec {
         }
 
         let output_spec_on_exit = if let Some(attr) = remove_unique_attr("unspec", attrs)? {
-            let unspec: UnspecAttr = attr.try_into()?;
+            let unspec = UnspecAttr::try_from(attr)?;
             match unspec.arg {
                 Some((_, UnspecArg::Out(_))) => false,
                 _ => {
-                    let attr: Attribute = unspec.into();
                     return Err(Error::new_spanned(
-                        attr,
+                        Attribute::from(unspec),
                         "only `#[unspec(out)]` is allowed on a `fn` output",
                     ));
                 }
@@ -396,7 +395,7 @@ impl DataSpec {
                     return Ok(true);
                 };
 
-                let unspec: UnspecAttr = attr.try_into()?;
+                let unspec = UnspecAttr::try_from(attr)?;
                 if unspec.arg.is_some() {
                     return Err(Error::new_spanned(
                         Attribute::from(unspec),

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -7,11 +7,12 @@ use syn::{
 
 use crate::{
     Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
-    annotate::syntax::SpecFields, qualifiers::FnQualifiers,
+    qualifiers::FnQualifiers,
+    syntax::{
+        attr::{get_attr_input, remove_spec_attr},
+        spec::{Keyword, SpecFields},
+    },
 };
-
-pub mod syntax;
-use syntax::{Keyword, get_attr_input, remove_spec_attr};
 
 #[cfg(test)]
 #[path = "annotate_tests.rs"]

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use crate::{
-    Capture, Condition, DataSpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
+    Capture, Condition, DataSpec, EmptySpec, FnSpec, LoopSpec, LoopVariant, PostCondition,
     qualifiers::FnQualifiers,
     syntax::{
         attr::{get_attr_input, remove_unique_attr},
@@ -88,7 +88,7 @@ impl Specified for TraitItemFn {
 }
 
 impl Specified for ItemImpl {
-    type Spec = DataSpec;
+    type Spec = EmptySpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
@@ -100,7 +100,7 @@ impl Specified for ItemImpl {
 }
 
 impl Specified for ItemTrait {
-    type Spec = DataSpec;
+    type Spec = EmptySpec;
 
     fn get_attrs_mut(&mut self) -> &mut Vec<Attribute> {
         &mut self.attrs
@@ -388,6 +388,21 @@ impl TryFrom<SpecFields> for LoopSpec {
             decreases,
             span,
         })
+    }
+}
+
+impl TryFrom<SpecFields> for EmptySpec {
+    type Error = Error;
+
+    fn try_from(fields: SpecFields) -> Result<Self> {
+        if fields.fields.is_empty() {
+            Ok(Self)
+        } else {
+            Err(Error::new_spanned(
+                fields,
+                "this `#[spec]` attribute must have no fields",
+            ))
+        }
     }
 }
 

--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use syn::{
-    Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, ImplItemFn, ItemEnum,
-    ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, TraitItemFn, parse::Result, parse_quote,
-    spanned::Spanned,
+    Attribute, Error, Expr, ExprAssign, ExprForLoop, ExprWhile, FieldValue, FnArg, ImplItemFn,
+    ItemEnum, ItemFn, ItemImpl, ItemStruct, ItemTrait, Meta, Token, TraitItemFn, parse::Result,
+    parse_quote, punctuated::Punctuated, spanned::Spanned,
 };
 
 use crate::{
@@ -162,24 +162,31 @@ impl Specified for ExprWhile {
 
 impl FnSpec {
     pub fn from_spec_and_fn(raw_spec: SpecFields, item_fn: &mut ItemFn) -> Result<Self> {
-        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
-        let input_specs = vec![];
-        let output_spec_on_exit = false;
+        let (input_specs, output_spec_on_exit) =
+            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
         Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
     }
 
     pub fn from_spec_and_impl_fn(raw_spec: SpecFields, item_fn: &mut ImplItemFn) -> Result<Self> {
-        // TODO: Collect `#[unspec]` attributes and populate input and output specs.
-        let input_specs = vec![];
-        let output_spec_on_exit = false;
+        let (input_specs, output_spec_on_exit) =
+            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
         Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
     }
 
     pub fn from_spec_and_trait_fn(raw_spec: SpecFields, item_fn: &mut TraitItemFn) -> Result<Self> {
+        let (input_specs, output_spec_on_exit) =
+            Self::extract_unspec_info(&mut item_fn.sig.inputs, &mut item_fn.attrs)?;
+        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
+    }
+
+    fn extract_unspec_info(
+        inputs: &mut Punctuated<FnArg, Token![,]>,
+        attrs: &mut Vec<Attribute>,
+    ) -> Result<(Vec<InputSpec>, bool)> {
         // TODO: Collect `#[unspec]` attributes and populate input and output specs.
         let input_specs = vec![];
         let output_spec_on_exit = false;
-        Self::from_spec_and_unspec_info(raw_spec, input_specs, output_spec_on_exit)
+        Ok((input_specs, output_spec_on_exit))
     }
 
     fn from_spec_and_unspec_info(

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -6,6 +6,13 @@ use quote::ToTokens;
 use syn::{parse_quote, parse_str};
 
 #[test]
+#[should_panic(expected = "must have no fields")]
+fn empty_spec_rejects_nonempty_fields() {
+    let fields: crate::syntax::spec::SpecFields = parse_quote! { maintains: true };
+    let _: EmptySpec = fields.try_into().unwrap();
+}
+
+#[test]
 fn simple_spec() {
     let spec_item_fn: SpecItemFn = parse_quote! {
         #[spec(

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1,4 +1,6 @@
-use crate::test_util::{SpecItemFn, assert_spec_eq, assert_tokens_eq};
+use crate::test_util::{
+    SpecItemEnum, SpecItemFn, SpecItemStruct, assert_spec_eq, assert_tokens_eq,
+};
 
 use super::*;
 use proc_macro2::Span;
@@ -54,6 +56,58 @@ fn unspec_attributes_on_function_inputs_and_output() {
         fn f(x: X, y: Y, z: Z) -> R {}
     };
     assert_tokens_eq(&spec_item_fn.node, &expected_item);
+}
+
+#[test]
+fn unspec_attributes_on_struct_fields() {
+    let spec_item_struct: SpecItemStruct = parse_quote! {
+        #[spec]
+        struct S {
+            a: A,
+            #[unspec]
+            b: B,
+        }
+    };
+
+    assert_eq!(spec_item_struct.spec.field_specs, vec![vec![true, false]]);
+
+    let expected_item: ItemStruct = parse_quote! {
+        struct S {
+            a: A,
+            b: B,
+        }
+    };
+    assert_tokens_eq(&spec_item_struct.node, &expected_item);
+}
+
+#[test]
+fn unspec_attributes_on_enum_fields() {
+    let spec_item_enum: SpecItemEnum = parse_quote! {
+        #[spec]
+        enum E {
+            First(#[unspec] A, B),
+            Second {
+                c: C,
+                #[unspec]
+                d: D,
+            },
+            Third,
+        }
+    };
+
+    assert_eq!(
+        spec_item_enum.spec.field_specs,
+        vec![vec![false, true], vec![true, false], vec![]]
+    );
+
+    let expected_item: ItemEnum = parse_quote! {
+        enum E {
+            First(A, B),
+            Second { c: C, d: D },
+            Third,
+        }
+    };
+    assert_tokens_eq(&spec_item_enum.node, &expected_item);
 }
 
 #[test]

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1098,7 +1098,7 @@ fn captures_pattern_with_binding_modifier() {
 #[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_is_rejected_by_spec_fields() {
     let input = "captures: Person { name, age } =,";
-    let _: syntax::SpecFields = parse_str(input).unwrap();
+    let _: crate::syntax::spec::SpecFields = parse_str(input).unwrap();
 }
 
 #[test]
@@ -1130,7 +1130,7 @@ fn captures_with_extra_semicolon() {
 
 #[test]
 fn field_value_supports_shorthand_expression() {
-    let spec_fields: syntax::SpecFields = parse_quote! {
+    let spec_fields: crate::syntax::spec::SpecFields = parse_quote! {
         key_1,
         key_2: value,
         key_3: value as expr,

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -28,21 +28,21 @@ fn unspec_attributes_on_function_inputs_and_output() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![
-            InputSpec {
+        input_spec_flags: vec![
+            InputSpecFlags {
                 on_entry: true,
                 on_exit: false,
             },
-            InputSpec {
+            InputSpecFlags {
                 on_entry: false,
                 on_exit: true,
             },
-            InputSpec {
+            InputSpecFlags {
                 on_entry: false,
                 on_exit: false,
             },
         ],
-        output_spec_on_exit: false,
+        output_spec_flag: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -69,7 +69,10 @@ fn unspec_attributes_on_struct_fields() {
         }
     };
 
-    assert_eq!(spec_item_struct.spec.field_specs, vec![vec![true, false]]);
+    assert_eq!(
+        spec_item_struct.spec.field_spec_flags,
+        vec![vec![true, false]]
+    );
 
     let expected_item: ItemStruct = parse_quote! {
         struct S {
@@ -96,7 +99,7 @@ fn unspec_attributes_on_enum_fields() {
     };
 
     assert_eq!(
-        spec_item_enum.spec.field_specs,
+        spec_item_enum.spec.field_spec_flags,
         vec![vec![false, true], vec![true, false], vec![]]
     );
 
@@ -122,8 +125,8 @@ fn simple_spec() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![Condition {
             expr: parse_quote! { is_valid(x) },
             cfg: None,
@@ -150,8 +153,8 @@ fn fn_qualifiers_functional() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::FUNCTIONAL,
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -171,8 +174,8 @@ fn fn_qualifiers_pure_total() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::PURE | FnQualifiers::TOTAL,
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -200,8 +203,8 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
             | FnQualifiers::EFFECTFREE
             | FnQualifiers::INFALLIBLE
             | FnQualifiers::TERMINATING,
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -318,8 +321,8 @@ fn all_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && x.is_power_of_two() },
             cfg: None,
@@ -409,8 +412,8 @@ fn array_of_conditions() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x >= 0 },
@@ -452,8 +455,8 @@ fn ensures_with_explicit_closure() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -482,8 +485,8 @@ fn multiple_clauses_of_same_flavor() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x > 0 || x < -10 },
@@ -538,8 +541,8 @@ fn mixed_single_and_array_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x == 0 },
@@ -603,8 +606,8 @@ fn cfg_attributes() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && is_mode() },
             cfg: Some(parse_quote! { test }),
@@ -672,8 +675,8 @@ fn macro_in_condition() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle) },
             cfg: None,
@@ -708,8 +711,8 @@ fn binds_pattern() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -747,8 +750,8 @@ fn multiple_conditions() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { self.initialized },
@@ -789,8 +792,8 @@ fn rename_return_value() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -824,8 +827,8 @@ fn captures_simple_identifier() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -855,8 +858,8 @@ fn captures_identifier_with_alias() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -894,8 +897,8 @@ fn captures_array() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -949,8 +952,8 @@ fn captures_with_all_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 },
             cfg: None,
@@ -998,8 +1001,8 @@ fn captures_array_expression() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1057,8 +1060,8 @@ fn captures_edge_case_cast_expr() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1085,8 +1088,8 @@ fn captures_edge_case_array_of_cast_exprs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1121,8 +1124,8 @@ fn captures_edge_case_list_of_cast_exprs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -1155,8 +1158,8 @@ fn captures_pattern_matches_slices() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1179,8 +1182,8 @@ fn captures_pattern_matches_tuples() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1203,8 +1206,8 @@ fn captures_pattern_matches_structs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1227,8 +1230,8 @@ fn captures_pattern_matches_nested() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
-        input_specs: vec![],
-        output_spec_on_exit: true,
+        input_spec_flags: vec![],
+        output_spec_flag: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -10,7 +10,7 @@ use syn::{parse_quote, parse_str};
 #[test]
 #[should_panic(expected = "must have no fields")]
 fn empty_spec_rejects_nonempty_fields() {
-    let fields: crate::syntax::spec::SpecFields = parse_quote! { maintains: true };
+    let fields: crate::syntax::SpecFields = parse_quote! { maintains: true };
     let _: EmptySpec = fields.try_into().unwrap();
 }
 
@@ -1258,7 +1258,7 @@ fn captures_pattern_with_binding_modifier() {
 #[should_panic(expected = "expected an expression")]
 fn captures_missing_assignment_value_is_rejected_by_spec_fields() {
     let input = "captures: Person { name, age } =,";
-    let _: crate::syntax::spec::SpecFields = parse_str(input).unwrap();
+    let _: crate::syntax::SpecFields = parse_str(input).unwrap();
 }
 
 #[test]
@@ -1290,7 +1290,7 @@ fn captures_with_extra_semicolon() {
 
 #[test]
 fn field_value_supports_shorthand_expression() {
-    let spec_fields: crate::syntax::spec::SpecFields = parse_quote! {
+    let spec_fields: crate::syntax::SpecFields = parse_quote! {
         key_1,
         key_2: value,
         key_3: value as expr,

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1,4 +1,4 @@
-use crate::test_util::{SpecItemFn, assert_spec_eq};
+use crate::test_util::{SpecItemFn, assert_spec_eq, assert_tokens_eq};
 
 use super::*;
 use proc_macro2::Span;
@@ -10,6 +10,50 @@ use syn::{parse_quote, parse_str};
 fn empty_spec_rejects_nonempty_fields() {
     let fields: crate::syntax::spec::SpecFields = parse_quote! { maintains: true };
     let _: EmptySpec = fields.try_into().unwrap();
+}
+
+#[test]
+fn unspec_attributes_on_function_inputs_and_output() {
+    let spec_item_fn: SpecItemFn = parse_quote! {
+        #[spec]
+        #[unspec(out)]
+        fn f(
+            #[unspec(out)] x: X,
+            #[unspec(in)] y: Y,
+            #[unspec] z: Z,
+        ) -> R {}
+    };
+
+    let expected = FnSpec {
+        qualifiers: FnQualifiers::empty(),
+        input_specs: vec![
+            InputSpec {
+                on_entry: true,
+                on_exit: false,
+            },
+            InputSpec {
+                on_entry: false,
+                on_exit: true,
+            },
+            InputSpec {
+                on_entry: false,
+                on_exit: false,
+            },
+        ],
+        output_spec_on_exit: false,
+        requires: vec![],
+        maintains: vec![],
+        captures: vec![],
+        ensures: vec![],
+        span: Span::call_site(),
+    };
+
+    assert_spec_eq(&spec_item_fn.spec, &expected);
+
+    let expected_item: ItemFn = parse_quote! {
+        fn f(x: X, y: Y, z: Z) -> R {}
+    };
+    assert_tokens_eq(&spec_item_fn.node, &expected_item);
 }
 
 #[test]
@@ -25,7 +69,7 @@ fn simple_spec() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![Condition {
             expr: parse_quote! { is_valid(x) },
             cfg: None,
@@ -53,7 +97,7 @@ fn fn_qualifiers_functional() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::FUNCTIONAL,
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -74,7 +118,7 @@ fn fn_qualifiers_pure_total() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::PURE | FnQualifiers::TOTAL,
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -103,7 +147,7 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
             | FnQualifiers::INFALLIBLE
             | FnQualifiers::TERMINATING,
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -221,7 +265,7 @@ fn all_clauses() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && x.is_power_of_two() },
             cfg: None,
@@ -312,7 +356,7 @@ fn array_of_conditions() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x >= 0 },
@@ -355,7 +399,7 @@ fn ensures_with_explicit_closure() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -385,7 +429,7 @@ fn multiple_clauses_of_same_flavor() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x > 0 || x < -10 },
@@ -441,7 +485,7 @@ fn mixed_single_and_array_clauses() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { x == 0 },
@@ -506,7 +550,7 @@ fn cfg_attributes() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && is_mode() },
             cfg: Some(parse_quote! { test }),
@@ -575,7 +619,7 @@ fn macro_in_condition() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle) },
             cfg: None,
@@ -611,7 +655,7 @@ fn binds_pattern() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -650,7 +694,7 @@ fn multiple_conditions() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![
             Condition {
                 expr: parse_quote! { self.initialized },
@@ -692,7 +736,7 @@ fn rename_return_value() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -727,7 +771,7 @@ fn captures_simple_identifier() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -758,7 +802,7 @@ fn captures_identifier_with_alias() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -797,7 +841,7 @@ fn captures_array() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -852,7 +896,7 @@ fn captures_with_all_clauses() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 },
             cfg: None,
@@ -901,7 +945,7 @@ fn captures_array_expression() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -960,7 +1004,7 @@ fn captures_edge_case_cast_expr() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -988,7 +1032,7 @@ fn captures_edge_case_array_of_cast_exprs() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1024,7 +1068,7 @@ fn captures_edge_case_list_of_cast_exprs() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -1058,7 +1102,7 @@ fn captures_pattern_matches_slices() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1082,7 +1126,7 @@ fn captures_pattern_matches_tuples() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1106,7 +1150,7 @@ fn captures_pattern_matches_structs() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1130,7 +1174,7 @@ fn captures_pattern_matches_nested() {
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
         input_specs: vec![],
-        output_spec_on_exit: false,
+        output_spec_on_exit: true,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -17,6 +17,8 @@ fn simple_spec() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![Condition {
             expr: parse_quote! { is_valid(x) },
             cfg: None,
@@ -43,6 +45,8 @@ fn fn_qualifiers_functional() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::FUNCTIONAL,
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -62,6 +66,8 @@ fn fn_qualifiers_pure_total() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::PURE | FnQualifiers::TOTAL,
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -89,6 +95,8 @@ fn fn_qualifiers_deterministic_effectfree_infallible_terminating() {
             | FnQualifiers::EFFECTFREE
             | FnQualifiers::INFALLIBLE
             | FnQualifiers::TERMINATING,
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -205,6 +213,8 @@ fn all_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && x.is_power_of_two() },
             cfg: None,
@@ -294,6 +304,8 @@ fn array_of_conditions() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![
             Condition {
                 expr: parse_quote! { x >= 0 },
@@ -335,6 +347,8 @@ fn ensures_with_explicit_closure() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -363,6 +377,8 @@ fn multiple_clauses_of_same_flavor() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![
             Condition {
                 expr: parse_quote! { x > 0 || x < -10 },
@@ -417,6 +433,8 @@ fn mixed_single_and_array_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![
             Condition {
                 expr: parse_quote! { x == 0 },
@@ -480,6 +498,8 @@ fn cfg_attributes() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 && is_mode() },
             cfg: Some(parse_quote! { test }),
@@ -547,6 +567,8 @@ fn macro_in_condition() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![Condition {
             expr: parse_quote! { matches!(self.state, State::Idle) },
             cfg: None,
@@ -581,6 +603,8 @@ fn binds_pattern() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -618,6 +642,8 @@ fn multiple_conditions() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![
             Condition {
                 expr: parse_quote! { self.initialized },
@@ -658,6 +684,8 @@ fn rename_return_value() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![],
@@ -691,6 +719,8 @@ fn captures_simple_identifier() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -720,6 +750,8 @@ fn captures_identifier_with_alias() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -757,6 +789,8 @@ fn captures_array() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -810,6 +844,8 @@ fn captures_with_all_clauses() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![Condition {
             expr: parse_quote! { x > 0 },
             cfg: None,
@@ -857,6 +893,8 @@ fn captures_array_expression() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -914,6 +952,8 @@ fn captures_edge_case_cast_expr() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -940,6 +980,8 @@ fn captures_edge_case_array_of_cast_exprs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -974,6 +1016,8 @@ fn captures_edge_case_list_of_cast_exprs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![
@@ -1006,6 +1050,8 @@ fn captures_pattern_matches_slices() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1028,6 +1074,8 @@ fn captures_pattern_matches_tuples() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1050,6 +1098,8 @@ fn captures_pattern_matches_structs() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {
@@ -1072,6 +1122,8 @@ fn captures_pattern_matches_nested() {
 
     let expected = FnSpec {
         qualifiers: FnQualifiers::empty(),
+        input_specs: vec![],
+        output_spec_on_exit: false,
         requires: vec![],
         maintains: vec![],
         captures: vec![Capture {

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -5,7 +5,7 @@ use syn::{
     Signature, parse_quote,
 };
 
-use crate::{DataSpec, FnSpec};
+use crate::{EmptySpec, FnSpec};
 
 pub mod data;
 pub mod fns;
@@ -194,14 +194,18 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
         }
     }
 
-    pub fn instrument_item_impl(&self, spec: DataSpec, item_impl: ItemImpl) -> Result<TokenStream> {
+    pub fn instrument_item_impl(
+        &self,
+        spec: EmptySpec,
+        item_impl: ItemImpl,
+    ) -> Result<TokenStream> {
         let new_impl = self.instrument_impl(spec, item_impl)?;
         Ok(new_impl.to_token_stream())
     }
 
     pub fn instrument_item_trait(
         &self,
-        spec: DataSpec,
+        spec: EmptySpec,
         item_trait: ItemTrait,
     ) -> Result<TokenStream> {
         let new_trait = self.instrument_trait(spec, item_trait)?;
@@ -210,7 +214,7 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
 
     pub fn instrument_item_trait_impl(
         &self,
-        spec: DataSpec,
+        spec: EmptySpec,
         item_impl: ItemImpl,
     ) -> Result<TokenStream> {
         let new_trait_impl = self.instrument_trait_impl(spec, item_impl)?;

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -8,8 +8,9 @@ use syn::{
 
 use crate::{
     DataSpec,
-    annotate::{Specified as _, syntax::remove_spec_attr},
+    annotate::Specified as _,
     instrument::{Mode, make_item_error},
+    syntax::attr::remove_spec_attr,
 };
 
 impl Mode {

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -10,7 +10,7 @@ use crate::{
     DataSpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
-    syntax::attr::remove_spec_attr,
+    syntax::attr::remove_unique_attr,
 };
 
 impl Mode {
@@ -120,19 +120,19 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                     new_items.push(ImplItem::Fn(item_fn));
                 }
                 ImplItem::Const(mut const_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl const"));
                     }
                     new_items.push(ImplItem::Const(const_item));
                 }
                 ImplItem::Type(mut type_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl type"));
                     }
                     new_items.push(ImplItem::Type(type_item));
                 }
                 ImplItem::Macro(mut macro_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "impl macro"));
                     }
                     new_items.push(ImplItem::Macro(macro_item));

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -10,7 +10,7 @@ use crate::{
     EmptySpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
-    syntax::attr::remove_unique_attr,
+    syntax::remove_unique_attr,
 };
 
 impl Mode {

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec,
+    EmptySpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
     syntax::attr::remove_unique_attr,
@@ -18,14 +18,10 @@ impl Mode {
     ///
     /// Reasons why impl functions must be treated differently from free-standing functions:
     /// - The `__anodized_fn_try_*` function must be qualified as `Self::` inside an impl.
-    pub fn instrument_impl(&self, spec: DataSpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
+    pub fn instrument_impl(&self, _: EmptySpec, mut the_impl: ItemImpl) -> Result<ItemImpl> {
         if the_impl.trait_.is_some() {
             return Err(make_item_error(&the_impl, "trait impl"));
         };
-
-        if !spec.is_empty() {
-            return Err(spec.spec_err("Unsupported spec element on inherent impl."));
-        }
 
         let mut new_items = Vec::with_capacity(the_impl.items.len() * 4);
 

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -12,7 +12,7 @@ use crate::{
     EmptySpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
-    syntax::attr::remove_unique_attr,
+    syntax::remove_unique_attr,
 };
 
 impl Mode {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -9,7 +9,7 @@ use syn::{
 };
 
 use crate::{
-    DataSpec,
+    EmptySpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
     syntax::attr::remove_unique_attr,
@@ -24,17 +24,9 @@ impl Mode {
     ///    default impl performs runtime validation and calls the mangled function.
     pub fn instrument_trait(
         &self,
-        spec: DataSpec,
+        _: EmptySpec,
         mut the_trait: syn::ItemTrait,
     ) -> syn::Result<syn::ItemTrait> {
-        // Currently we don't support any spec fields for traits themselves.
-        if !spec.is_empty() {
-            return Err(spec.spec_err(
-                "Unsupported spec element on trait. Try placing it on an item inside the trait",
-            ));
-        }
-        let _ = move || spec;
-
         let mut new_trait_items = Vec::with_capacity(the_trait.items.len() * 5);
 
         for item in the_trait.items.into_iter() {
@@ -192,7 +184,7 @@ impl Mode {
     /// - The impl's postconditions must entail the trait's postconditions.
     pub fn instrument_trait_impl(
         &self,
-        spec: DataSpec,
+        _spec: EmptySpec,
         mut the_impl: syn::ItemImpl,
     ) -> syn::Result<syn::ItemImpl> {
         let Some((trait_bang, ref trait_path, _trait_for)) = the_impl.trait_ else {
@@ -201,10 +193,6 @@ impl Mode {
 
         if trait_bang.is_some() {
             return Err(make_item_error(&the_impl, "negative trait impl"));
-        }
-
-        if !spec.is_empty() {
-            return Err(spec.spec_err("Unsupported spec element on trait impl."));
         }
 
         let mut new_items = Vec::with_capacity(the_impl.items.len() * 4);

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -10,8 +10,9 @@ use syn::{
 
 use crate::{
     DataSpec,
-    annotate::{Specified as _, syntax::remove_spec_attr},
+    annotate::Specified as _,
     instrument::{Mode, make_item_error},
+    syntax::attr::remove_spec_attr,
 };
 
 impl Mode {

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -12,7 +12,7 @@ use crate::{
     DataSpec,
     annotate::Specified as _,
     instrument::{Mode, make_item_error},
-    syntax::attr::remove_spec_attr,
+    syntax::attr::remove_unique_attr,
 };
 
 impl Mode {
@@ -158,19 +158,19 @@ impl Mode {
                     new_trait_items.push(TraitItem::Fn(func));
                 }
                 TraitItem::Const(mut const_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait const"));
                     }
                     new_trait_items.push(TraitItem::Const(const_item));
                 }
                 TraitItem::Type(mut type_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait type"));
                     }
                     new_trait_items.push(TraitItem::Type(type_item));
                 }
                 TraitItem::Macro(mut macro_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait macro"));
                     }
                     new_trait_items.push(TraitItem::Macro(macro_item));
@@ -300,19 +300,19 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                     new_items.push(ImplItem::Fn(func));
                 }
                 ImplItem::Const(mut const_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut const_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut const_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl const"));
                     }
                     new_items.push(ImplItem::Const(const_item));
                 }
                 ImplItem::Type(mut type_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut type_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut type_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl type"));
                     }
                     new_items.push(ImplItem::Type(type_item));
                 }
                 ImplItem::Macro(mut macro_item) => {
-                    if let Some(spec_attr) = remove_spec_attr(&mut macro_item.attrs)? {
+                    if let Some(spec_attr) = remove_unique_attr("spec", &mut macro_item.attrs)? {
                         return Err(make_item_error(&spec_attr, "trait impl macro"));
                     }
                     new_items.push(ImplItem::Macro(macro_item));

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -13,6 +13,10 @@ pub mod syntax;
 #[cfg(test)]
 mod test_util;
 
+/// Mandates that an AST node's `#[spec]` attribute be empty, i.e. contain no fields.
+#[derive(Debug)]
+pub struct EmptySpec;
+
 /// Specifies the intended behavior of a function or method: `fn`.
 #[derive(Debug)]
 pub struct FnSpec {

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -8,6 +8,7 @@ use crate::qualifiers::FnQualifiers;
 pub mod annotate;
 pub mod instrument;
 pub mod qualifiers;
+pub mod syntax;
 
 #[cfg(test)]
 mod test_util;

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -18,6 +18,10 @@ mod test_util;
 pub struct FnSpec {
     /// Qualifiers that constrain the behavior of the computation.
     pub qualifiers: FnQualifiers,
+    /// Whether each input satisfies its type spec on entry/exit.
+    pub input_specs: Vec<InputSpec>,
+    /// Whether the output satisfies its type spec on exit.
+    pub output_spec_on_exit: bool,
     /// Preconditions: conditions that must hold when the function is called.
     pub requires: Vec<Condition>,
     /// Invariants: conditions that must hold both when the function is called and when it returns.
@@ -30,6 +34,15 @@ pub struct FnSpec {
     span: Span,
 }
 
+/// Determines where the input in a `fn` signature satisfies its type spec.
+#[derive(Debug)]
+pub struct InputSpec {
+    /// Whether the input satisfies its type spec on entry.
+    pub on_entry: bool,
+    /// Whether the input satisfies its type spec on exit.
+    pub on_exit: bool,
+}
+
 impl FnSpec {
     /// Returns `true` if the spec is empty (specifies nothing), otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
@@ -38,6 +51,11 @@ impl FnSpec {
             && self.maintains.is_empty()
             && self.ensures.is_empty()
             && self.captures.is_empty()
+            && !self.output_spec_on_exit
+            && !self
+                .input_specs
+                .iter()
+                .any(|input_spec| input_spec.on_entry || input_spec.on_exit)
     }
 
     /// Construct an error from the whole spec.
@@ -46,9 +64,20 @@ impl FnSpec {
     }
 }
 
+impl Default for InputSpec {
+    fn default() -> Self {
+        Self {
+            on_entry: true,
+            on_exit: true,
+        }
+    }
+}
+
 /// Specifies the intended behavior of a data type: `struct` or `enum`.
 #[derive(Debug)]
 pub struct DataSpec {
+    /// Whether each field satisfies its type spec. Variant index first, field index second.
+    pub field_specs: Vec<Vec<bool>>,
     /// Invariants: conditions that must hold for all instances of the data type.
     pub maintains: Vec<Condition>,
     /// The span in the source code, from which this spec was parsed.
@@ -59,6 +88,11 @@ impl DataSpec {
     /// Returns `true` if the spec is empty (specifies nothing), otherwise returns `false`.
     pub fn is_empty(&self) -> bool {
         self.maintains.is_empty()
+            && !self
+                .field_specs
+                .iter()
+                .flatten()
+                .any(|field_spec| *field_spec)
     }
 
     /// Construct an error from the whole spec.

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -23,9 +23,9 @@ pub struct FnSpec {
     /// Qualifiers that constrain the behavior of the computation.
     pub qualifiers: FnQualifiers,
     /// Whether each input satisfies its type spec on entry/exit.
-    pub input_specs: Vec<InputSpec>,
+    pub input_spec_flags: Vec<InputSpecFlags>,
     /// Whether the output satisfies its type spec on exit.
-    pub output_spec_on_exit: bool,
+    pub output_spec_flag: bool,
     /// Preconditions: conditions that must hold when the function is called.
     pub requires: Vec<Condition>,
     /// Invariants: conditions that must hold both when the function is called and when it returns.
@@ -40,7 +40,7 @@ pub struct FnSpec {
 
 /// Determines where the input in a `fn` signature satisfies its type spec.
 #[derive(Debug)]
-pub struct InputSpec {
+pub struct InputSpecFlags {
     /// Whether the input satisfies its type spec on entry.
     pub on_entry: bool,
     /// Whether the input satisfies its type spec on exit.
@@ -55,9 +55,9 @@ impl FnSpec {
             && self.maintains.is_empty()
             && self.ensures.is_empty()
             && self.captures.is_empty()
-            && !self.output_spec_on_exit
+            && !self.output_spec_flag
             && !self
-                .input_specs
+                .input_spec_flags
                 .iter()
                 .any(|input_spec| input_spec.on_entry || input_spec.on_exit)
     }
@@ -68,7 +68,7 @@ impl FnSpec {
     }
 }
 
-impl Default for InputSpec {
+impl Default for InputSpecFlags {
     fn default() -> Self {
         Self {
             on_entry: true,
@@ -81,7 +81,7 @@ impl Default for InputSpec {
 #[derive(Debug)]
 pub struct DataSpec {
     /// Whether each field satisfies its type spec. Variant index first, field index second.
-    pub field_specs: Vec<Vec<bool>>,
+    pub field_spec_flags: Vec<Vec<bool>>,
     /// Invariants: conditions that must hold for all instances of the data type.
     pub maintains: Vec<Condition>,
     /// The span in the source code, from which this spec was parsed.
@@ -93,7 +93,7 @@ impl DataSpec {
     pub fn is_empty(&self) -> bool {
         self.maintains.is_empty()
             && !self
-                .field_specs
+                .field_spec_flags
                 .iter()
                 .flatten()
                 .any(|field_spec| *field_spec)

--- a/crates/anodized-core/src/syntax.rs
+++ b/crates/anodized-core/src/syntax.rs
@@ -1,2 +1,3 @@
 pub mod attr;
 pub mod spec;
+pub mod unspec;

--- a/crates/anodized-core/src/syntax.rs
+++ b/crates/anodized-core/src/syntax.rs
@@ -1,3 +1,7 @@
 pub mod attr;
 pub mod spec;
 pub mod unspec;
+
+pub use attr::*;
+pub use spec::*;
+pub use unspec::*;

--- a/crates/anodized-core/src/syntax.rs
+++ b/crates/anodized-core/src/syntax.rs
@@ -1,0 +1,2 @@
+pub mod attr;
+pub mod spec;

--- a/crates/anodized-core/src/syntax/attr.rs
+++ b/crates/anodized-core/src/syntax/attr.rs
@@ -1,0 +1,49 @@
+use proc_macro2::TokenStream;
+use syn::{Attribute, Error, Meta, Path, parse::Result};
+
+/// Removes a single `#[spec]` attribute, if present, from an attribute list.
+///
+/// If there are multiple `#[spec]` attributes, returns `Err`.
+/// The arguments of the `#[spec]` attribute are *not* validated.
+pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
+    let mut maybe_index = None;
+
+    for (i, attr) in attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
+    {
+        if maybe_index.is_some() {
+            return Err(Error::new_spanned(
+                attr,
+                "multiple `#[spec]` attributes are not allowed",
+            ));
+        }
+        maybe_index = Some(i);
+    }
+
+    if let Some(index) = maybe_index {
+        Ok(Some(attrs.remove(index)))
+    } else {
+        Ok(None)
+    }
+}
+
+fn path_matches_name(path: &Path, name: &str) -> bool {
+    path.get_ident().is_some_and(|ident| *ident == name)
+}
+
+/// Get the `TokenStream` that represents the arguments of an `Attribute`.
+///
+/// - If the attribute has no arguments, returns an empty stream.
+/// - If the attribute has a `key = value` style argument, returns an error.
+pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
+    match attr.meta {
+        Meta::Path(_) => Ok(TokenStream::new()),
+        Meta::List(list) => Ok(list.tokens),
+        Meta::NameValue(key_value) => Err(Error::new_spanned(
+            key_value.eq_token,
+            "expected arguments between delimiters `()`, `[]`, or `{}`",
+        )),
+    }
+}

--- a/crates/anodized-core/src/syntax/attr.rs
+++ b/crates/anodized-core/src/syntax/attr.rs
@@ -5,18 +5,18 @@ use syn::{Attribute, Error, Meta, Path, parse::Result};
 ///
 /// If there are multiple `#[spec]` attributes, returns `Err`.
 /// The arguments of the `#[spec]` attribute are *not* validated.
-pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
+pub fn remove_unique_attr(name: &str, attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
     let mut maybe_index = None;
 
     for (i, attr) in attrs
         .iter()
         .enumerate()
-        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
+        .filter(|(_, attr)| path_matches_name(attr.path(), name))
     {
         if maybe_index.is_some() {
             return Err(Error::new_spanned(
                 attr,
-                "multiple `#[spec]` attributes are not allowed",
+                format!("multiple `#[{name}]` attributes are not allowed"),
             ));
         }
         maybe_index = Some(i);
@@ -29,7 +29,7 @@ pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>>
     }
 }
 
-fn path_matches_name(path: &Path, name: &str) -> bool {
+pub fn path_matches_name(path: &Path, name: &str) -> bool {
     path.get_ident().is_some_and(|ident| *ident == name)
 }
 

--- a/crates/anodized-core/src/syntax/attr.rs
+++ b/crates/anodized-core/src/syntax/attr.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
 use syn::{Attribute, Error, Meta, Path, parse::Result};
 
-/// Removes a single `#[spec]` attribute, if present, from an attribute list.
+/// Removes a single attribute with the given name, if present, from an attribute list.
 ///
-/// If there are multiple `#[spec]` attributes, returns `Err`.
-/// The arguments of the `#[spec]` attribute are *not* validated.
+/// If there are multiple matching attributes, returns `Err`.
+/// The attribute's arguments are *not* validated.
 pub fn remove_unique_attr(name: &str, attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
     let mut maybe_index = None;
 

--- a/crates/anodized-core/src/syntax/spec.rs
+++ b/crates/anodized-core/src/syntax/spec.rs
@@ -1,7 +1,6 @@
-use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{
-    Attribute, Error, FieldValue, Ident, Member, Meta, Path, Token,
+    FieldValue, Ident, Member, Token,
     parse::{Parse, ParseStream, Result},
     punctuated::Punctuated,
 };
@@ -106,53 +105,5 @@ impl std::fmt::Display for Keyword {
             Keyword::Ensures => write!(f, "ensures"),
             Keyword::Decreases => write!(f, "decreases"),
         }
-    }
-}
-
-/// Removes a single `#[spec]` attribute, if present, from an attribute list.
-///
-/// If there are multiple `#[spec]` attributes, returns `Err`.
-/// The arguments of the `#[spec]` attribute are *not* validated.
-pub fn remove_spec_attr(attrs: &mut Vec<Attribute>) -> Result<Option<Attribute>> {
-    let mut maybe_index = None;
-
-    for (i, attr) in attrs
-        .iter()
-        .enumerate()
-        .filter(|(_, attr)| path_matches_name(attr.path(), "spec"))
-    {
-        if maybe_index.is_some() {
-            return Err(Error::new_spanned(
-                attr,
-                "multiple `#[spec]` attributes are not allowed",
-            ));
-        }
-        maybe_index = Some(i);
-    }
-
-    if let Some(index) = maybe_index {
-        let attr = attrs.remove(index);
-        Ok(Some(attr))
-    } else {
-        Ok(None)
-    }
-}
-
-fn path_matches_name(path: &Path, name: &str) -> bool {
-    path.get_ident().is_some_and(|ident| *ident == name)
-}
-
-/// Get the `TokenStream` that represents the arguments of an `Attribute`.
-///
-/// - If the attribute has no arguments, returns an empty stream.
-/// - If the attribute has a `key = value` style argument, returns an error.
-pub fn get_attr_input(attr: Attribute) -> Result<TokenStream> {
-    match attr.meta {
-        Meta::Path(_) => Ok(TokenStream::new()),
-        Meta::List(list) => Ok(list.tokens),
-        Meta::NameValue(key_value) => Err(Error::new_spanned(
-            key_value.eq_token,
-            "expected arguments between delimiters `()`, `[]`, or `{}`",
-        )),
     }
 }

--- a/crates/anodized-core/src/syntax/unspec.rs
+++ b/crates/anodized-core/src/syntax/unspec.rs
@@ -6,7 +6,7 @@ use syn::{
     token::{Bracket, Paren, Pound},
 };
 
-use crate::syntax::attr::path_matches_name;
+use crate::syntax::path_matches_name;
 
 /// Represents a valid `#[unspec]` attribute.
 ///

--- a/crates/anodized-core/src/syntax/unspec.rs
+++ b/crates/anodized-core/src/syntax/unspec.rs
@@ -1,0 +1,128 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{
+    AttrStyle, Attribute, Error, MacroDelimiter, Meta, MetaList, Path, Token,
+    parse::{Parse, ParseStream, Result},
+    token::{Bracket, Paren, Pound},
+};
+
+use crate::syntax::attr::path_matches_name;
+
+/// Represents a valid `#[unspec]` attribute.
+///
+/// Has three valid forms:
+/// - `#[unspec]`
+/// - `#[unspec(in)]`
+/// - `#[unspec(out)]`
+#[derive(Debug, Clone)]
+pub struct UnspecAttr {
+    pub pound_token: Pound,
+    pub bracket_token: Bracket,
+    pub path: Path,
+    pub arg: Option<(Paren, UnspecArg)>,
+}
+
+impl From<UnspecAttr> for Attribute {
+    fn from(unspec: UnspecAttr) -> Self {
+        Attribute {
+            pound_token: unspec.pound_token,
+            style: AttrStyle::Outer,
+            bracket_token: unspec.bracket_token,
+            meta: if let Some((paren, arg)) = unspec.arg {
+                Meta::List(MetaList {
+                    path: unspec.path,
+                    delimiter: MacroDelimiter::Paren(paren),
+                    tokens: arg.into_token_stream(),
+                })
+            } else {
+                Meta::Path(unspec.path)
+            },
+        }
+    }
+}
+
+impl TryFrom<Attribute> for UnspecAttr {
+    type Error = Error;
+
+    fn try_from(attr: Attribute) -> Result<Self> {
+        if let AttrStyle::Inner(bang_token) = attr.style {
+            return Err(syn::Error::new_spanned(
+                bang_token,
+                "expected an outer attribute (no `!`): `#[unspec]`",
+            ));
+        };
+
+        let (path, arg) = match attr.meta {
+            Meta::Path(path) if path_matches_name(&path, "unspec") => (path, None),
+            Meta::List(list) if path_matches_name(&list.path, "unspec") => {
+                let MacroDelimiter::Paren(paren) = list.delimiter else {
+                    return Err(Error::new(
+                        list.delimiter.span().open(),
+                        "expected arguments in parentheses",
+                    ));
+                };
+                let arg = list.parse_args()?;
+                (list.path, Some((paren, arg)))
+            }
+            Meta::NameValue(key_val) if path_matches_name(&key_val.path, "unspec") => {
+                return Err(Error::new_spanned(
+                    key_val.eq_token,
+                    "expected arguments in parentheses",
+                ));
+            }
+            _ => {
+                return Err(Error::new_spanned(
+                    attr,
+                    "expected an `#[unspec]` attribute",
+                ));
+            }
+        };
+
+        Ok(UnspecAttr {
+            pound_token: attr.pound_token,
+            bracket_token: attr.bracket_token,
+            path,
+            arg,
+        })
+    }
+}
+
+/// Represents valid arguments to the `#[unspec]` attribute.
+#[derive(Debug, Clone, Copy)]
+pub enum UnspecArg {
+    /// An `in` argument, as in `#[unspec(in)]`.
+    In(Token![in]),
+    /// An `out` argument, as in `#[unspec(out)]`.
+    Out(kw::out),
+}
+
+impl ToTokens for UnspecArg {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            UnspecArg::In(in_token) => in_token.to_tokens(tokens),
+            UnspecArg::Out(out_token) => out_token.to_tokens(tokens),
+        }
+    }
+}
+
+impl Parse for UnspecArg {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let arg = if input.peek(Token![in]) {
+            Self::In(input.parse::<Token![in]>()?)
+        } else if input.peek(kw::out) {
+            Self::Out(input.parse::<kw::out>()?)
+        } else {
+            return Err(input.error("expected `in` or `out`"));
+        };
+
+        if !input.is_empty() {
+            return Err(input.error("expected exactly one argument"));
+        }
+
+        Ok(arg)
+    }
+}
+
+mod kw {
+    syn::custom_keyword!(out);
+}

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -58,8 +58,8 @@ pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
     // Destructure to ensure we handle all fields - compilation will fail if fields are added
     let FnSpec {
         qualifiers: left_qualifiers,
-        input_specs: left_input_specs,
-        output_spec_on_exit: left_output_spec_on_exit,
+        input_spec_flags: left_input_specs,
+        output_spec_flag: left_output_spec_on_exit,
         requires: left_requires,
         maintains: left_maintains,
         captures: left_captures,
@@ -69,8 +69,8 @@ pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
 
     let FnSpec {
         qualifiers: right_qualifiers,
-        input_specs: right_input_specs,
-        output_spec_on_exit: right_output_spec_on_exit,
+        input_spec_flags: right_input_specs,
+        output_spec_flag: right_output_spec_on_exit,
         requires: right_requires,
         maintains: right_maintains,
         captures: right_captures,

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Capture, Condition, DataSpec, FnSpec, PostCondition, annotate::Specified,
+    Capture, Condition, DataSpec, EmptySpec, FnSpec, PostCondition, annotate::Specified,
     instrument::patterns::TamePat,
 };
 use pretty_assertions::assert_eq;
@@ -10,10 +10,10 @@ use syn::parse::{Parse, ParseStream};
 pub type SpecItemFn = NodeWithSpec<FnSpec, syn::ItemFn>;
 
 /// Specified `impl`.
-pub type SpecItemImpl = NodeWithSpec<DataSpec, syn::ItemImpl>;
+pub type SpecItemImpl = NodeWithSpec<EmptySpec, syn::ItemImpl>;
 
 /// Specified `trait`.
-pub type SpecItemTrait = NodeWithSpec<DataSpec, syn::ItemTrait>;
+pub type SpecItemTrait = NodeWithSpec<EmptySpec, syn::ItemTrait>;
 
 /// Specified `struct`.
 pub type SpecItemStruct = NodeWithSpec<DataSpec, syn::ItemStruct>;

--- a/crates/anodized-core/src/test_util.rs
+++ b/crates/anodized-core/src/test_util.rs
@@ -58,6 +58,8 @@ pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
     // Destructure to ensure we handle all fields - compilation will fail if fields are added
     let FnSpec {
         qualifiers: left_qualifiers,
+        input_specs: left_input_specs,
+        output_spec_on_exit: left_output_spec_on_exit,
         requires: left_requires,
         maintains: left_maintains,
         captures: left_captures,
@@ -67,6 +69,8 @@ pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
 
     let FnSpec {
         qualifiers: right_qualifiers,
+        input_specs: right_input_specs,
+        output_spec_on_exit: right_output_spec_on_exit,
         requires: right_requires,
         maintains: right_maintains,
         captures: right_captures,
@@ -77,6 +81,25 @@ pub fn assert_spec_eq(left: &FnSpec, right: &FnSpec) {
     assert_eq!(
         left_qualifiers, right_qualifiers,
         "qualifiers do not match: {left_qualifiers:?} vs {right_qualifiers:?}"
+    );
+    assert_eq!(
+        left_output_spec_on_exit, right_output_spec_on_exit,
+        "output spec on exit does not match"
+    );
+    assert_slice_eq(
+        left_input_specs,
+        right_input_specs,
+        "input specs",
+        |left, right, message| {
+            assert_eq!(
+                left.on_entry, right.on_entry,
+                "{message} entry flags do not match"
+            );
+            assert_eq!(
+                left.on_exit, right.on_exit,
+                "{message} exit flags do not match"
+            );
+        },
     );
 
     assert_slice_eq(

--- a/crates/anodized-fmt/src/formatter/spec.rs
+++ b/crates/anodized-fmt/src/formatter/spec.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anodized_core::syntax::spec::{Keyword, SpecFields};
+use anodized_core::syntax::{Keyword, SpecFields};
 use syn::FieldValue;
 use syn::spanned::Spanned;
 

--- a/crates/anodized-fmt/src/formatter/spec.rs
+++ b/crates/anodized-fmt/src/formatter/spec.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anodized_core::annotate::syntax::{Keyword, SpecFields};
+use anodized_core::syntax::spec::{Keyword, SpecFields};
 use syn::FieldValue;
 use syn::spanned::Spanned;
 

--- a/crates/anodized-fmt/src/source_file.rs
+++ b/crates/anodized-fmt/src/source_file.rs
@@ -11,7 +11,7 @@ use crate::{
     formatter::format_spec_attribute,
 };
 
-use anodized_core::syntax::spec::SpecFields;
+use anodized_core::syntax::SpecFields;
 
 #[derive(Debug)]
 struct TextEdit {

--- a/crates/anodized-fmt/src/source_file.rs
+++ b/crates/anodized-fmt/src/source_file.rs
@@ -11,7 +11,7 @@ use crate::{
     formatter::format_spec_attribute,
 };
 
-use anodized_core::annotate::syntax::SpecFields;
+use anodized_core::syntax::spec::SpecFields;
 
 #[derive(Debug)]
 struct TextEdit {

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -38,7 +38,12 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
 /// *not* support macro attributes on inputs of a `fn` or fields of a `struct` or `enum`.
 #[proc_macro_attribute]
 pub fn unspec(_: TokenStream, _: TokenStream) -> TokenStream {
-    unimplemented!("`anodized-core` should have removed this attribute.")
+    syn::Error::new(
+        Span::call_site(),
+        "must be on or inside the item of a `#[spec]` attribute",
+    )
+    .to_compile_error()
+    .into()
 }
 
 /// Attaches a specification to supported program elements.

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -6,8 +6,9 @@ use quote::ToTokens;
 use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 
 use anodized_core::{
-    annotate::{Specified as _, syntax::SpecFields},
+    annotate::Specified as _,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
+    syntax::spec::SpecFields,
 };
 
 const CONFIG: Mode = if cfg!(anodized_discard_specs) {

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -26,6 +26,21 @@ const CONFIG: Mode = if cfg!(anodized_discard_specs) {
     })
 };
 
+/// **Must** be inside a `#[spec]` attribute's item. May be applied to a `fn`, its inputs, and
+/// fields of a `struct` or `enum`.
+///
+/// - `#[unspec]`: The input or field may *not* satisfy its type spec.
+/// - `#[unspec(in)]`: The input may *not* satisfy its type spec at entry.
+/// - `#[unspec(out)]`: The input or output may *not* satisfy its type spec at exit.
+///
+/// This macro exists *only* to carry this documentation. It will never be invoked, because
+/// `anodized-core` removes it as part of processing `#[spec]` attributes. Note that Rust does
+/// *not* support macro attributes on inputs of a `fn` or fields of a `struct` or `enum`.
+#[proc_macro_attribute]
+pub fn unspec(_: TokenStream, _: TokenStream) -> TokenStream {
+    unimplemented!("`anodized-core` should have removed this attribute.")
+}
+
 /// Attaches a specification to supported program elements.
 ///
 /// This macro parses the spec and transforms the item's code to provide the following features:

--- a/crates/anodized-macros/src/lib.rs
+++ b/crates/anodized-macros/src/lib.rs
@@ -8,7 +8,7 @@ use syn::{Expr, Item, TraitItemFn, parse_macro_input};
 use anodized_core::{
     annotate::Specified as _,
     instrument::{CheckSettings, Mode, PanicSettings, fns::make_try_call, make_item_error},
-    syntax::spec::SpecFields,
+    syntax::SpecFields,
 };
 
 const CONFIG: Mode = if cfg!(anodized_discard_specs) {

--- a/crates/anodized/src/lib.rs
+++ b/crates/anodized/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use anodized_logic as logic;
 pub use anodized_logic::arithmetic;
-pub use anodized_macros::spec;
+pub use anodized_macros::{spec, unspec};
 
 pub mod __;
 pub mod result;

--- a/crates/anodized/tests/compile_fail/unspec_duplicate_input.rs
+++ b/crates/anodized/tests/compile_fail/unspec_duplicate_input.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#![allow(unused_imports)]
+
+use anodized::{spec, unspec};
+
+#[spec]
+fn f(#[unspec] #[unspec(in)] x: i32) {}

--- a/crates/anodized/tests/compile_fail/unspec_duplicate_input.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_duplicate_input.stderr
@@ -1,0 +1,5 @@
+error: multiple `#[unspec]` attributes are not allowed
+ --> tests/compile_fail/unspec_duplicate_input.rs:7:16
+  |
+7 | fn f(#[unspec] #[unspec(in)] x: i32) {}
+  |                ^^^^^^^^^^^^^

--- a/crates/anodized/tests/compile_fail/unspec_invalid_field_form.rs
+++ b/crates/anodized/tests/compile_fail/unspec_invalid_field_form.rs
@@ -1,0 +1,10 @@
+#![no_main]
+#![allow(unused_imports)]
+
+use anodized::{spec, unspec};
+
+#[spec]
+struct S {
+    #[unspec(out)]
+    field: i32,
+}

--- a/crates/anodized/tests/compile_fail/unspec_invalid_field_form.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_invalid_field_form.stderr
@@ -1,0 +1,5 @@
+error: expected `#[unspec]` on a struct or enum field
+ --> tests/compile_fail/unspec_invalid_field_form.rs:8:5
+  |
+8 |     #[unspec(out)]
+  |     ^^^^^^^^^^^^^^

--- a/crates/anodized/tests/compile_fail/unspec_invalid_field_form.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_invalid_field_form.stderr
@@ -1,4 +1,4 @@
-error: expected `#[unspec]` on a struct or enum field
+error: only `#[unspec]` is allowed on a field
  --> tests/compile_fail/unspec_invalid_field_form.rs:8:5
   |
 8 |     #[unspec(out)]

--- a/crates/anodized/tests/compile_fail/unspec_invalid_function_form.rs
+++ b/crates/anodized/tests/compile_fail/unspec_invalid_function_form.rs
@@ -1,0 +1,8 @@
+#![no_main]
+#![allow(unused_imports)]
+
+use anodized::{spec, unspec};
+
+#[spec]
+#[unspec]
+fn f() {}

--- a/crates/anodized/tests/compile_fail/unspec_invalid_function_form.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_invalid_function_form.stderr
@@ -1,0 +1,5 @@
+error: only `#[unspec(out)]` is allowed on a `fn` output
+ --> tests/compile_fail/unspec_invalid_function_form.rs:7:1
+  |
+7 | #[unspec]
+  | ^^^^^^^^^

--- a/crates/anodized/tests/compile_fail/unspec_multiple_arguments.rs
+++ b/crates/anodized/tests/compile_fail/unspec_multiple_arguments.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#![allow(unused_imports)]
+
+use anodized::{spec, unspec};
+
+#[spec]
+fn f(#[unspec(in, out)] x: i32) {}

--- a/crates/anodized/tests/compile_fail/unspec_multiple_arguments.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_multiple_arguments.stderr
@@ -1,0 +1,5 @@
+error: expected exactly one argument
+ --> tests/compile_fail/unspec_multiple_arguments.rs:7:17
+  |
+7 | fn f(#[unspec(in, out)] x: i32) {}
+  |                 ^

--- a/crates/anodized/tests/compile_fail/unspec_unknown_argument.rs
+++ b/crates/anodized/tests/compile_fail/unspec_unknown_argument.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#![allow(unused_imports)]
+
+use anodized::{spec, unspec};
+
+#[spec]
+fn f(#[unspec(entry)] x: i32) {}

--- a/crates/anodized/tests/compile_fail/unspec_unknown_argument.stderr
+++ b/crates/anodized/tests/compile_fail/unspec_unknown_argument.stderr
@@ -1,0 +1,5 @@
+error: expected `in` or `out`
+ --> tests/compile_fail/unspec_unknown_argument.rs:7:15
+  |
+7 | fn f(#[unspec(entry)] x: i32) {}
+  |               ^^^^^

--- a/crates/anodized/tests/unspec_attribute.rs
+++ b/crates/anodized/tests/unspec_attribute.rs
@@ -1,4 +1,3 @@
-#![no_main]
 #![allow(unused)]
 
 use anodized::{spec, unspec};

--- a/crates/anodized/tests/unspec_attribute.rs
+++ b/crates/anodized/tests/unspec_attribute.rs
@@ -1,36 +1,56 @@
 #![no_main]
+#![allow(unused)]
 
 use anodized::{spec, unspec};
 
-// Default: all inputs must satisfy their type specs on both entry and exit, and the output on exit.
-#[spec]
-fn one(x: P, y: &mut Q) -> R;
+/// A `struct` with a type spec, a.k.a. refinement.
+#[spec(
+    maintains: [
+        // Something something...
+        todo!()
+    ],
+)]
+struct T;
 
-// Input `x` is "unspec-ified" (i.e. may not satisfy its type spec) on exit:
+/// Default: all inputs satisfy their type specs on both entry and exit, and the output on exit.
 #[spec]
-fn two(#[unspec(out)] x: P, y: &mut Q) -> R;
+fn one(x: T, y: &mut T) -> T {
+    todo!()
+}
 
-// Input `y` is unspecified on entry:
+/// Input `x` may not satisfy its type spec on exit.
 #[spec]
-fn three(x: P, #[unspec(in)] y: &mut Q) -> R;
+fn two(#[unspec(out)] x: T, y: &mut T) -> T {
+    todo!()
+}
 
-// Input `y` is unspecified on both entry and exit:
+/// Input `y` may not satisfy its type spec on entry.
 #[spec]
-fn four(x: P, #[unspec] y: &mut Q) -> R;
+fn three(x: T, #[unspec(in)] y: &mut T) -> T {
+    todo!()
+}
 
-// The output is unspecified on exit:
+/// Input `y` may not satisfy its type spec on both entry and exit.
+#[spec]
+fn four(x: T, #[unspec] y: &mut T) -> T {
+    todo!()
+}
+
+/// The output may not satisfy its type spec on exit.
 #[spec]
 #[unspec(out)]
-fn five(x: P, y: &mut Q) -> R;
+fn five(x: T, y: &mut T) -> T {
+    todo!()
+}
 
-// Default: all fields must satisfy their type specs:
+/// Default: all fields must satisfy their type specs.
 #[spec]
 struct Six {
     pub a: T,
     pub b: T,
 }
 
-// The field `b` is unspecified:
+/// The field `b` may not satisfy its type spec.
 #[spec]
 struct Seven {
     pub a: T,

--- a/crates/anodized/tests/unspec_attribute.rs
+++ b/crates/anodized/tests/unspec_attribute.rs
@@ -1,0 +1,39 @@
+#![no_main]
+
+use anodized::{spec, unspec};
+
+// Default: all inputs must satisfy their type specs on both entry and exit, and the output on exit.
+#[spec]
+fn one(x: P, y: &mut Q) -> R;
+
+// Input `x` is "unspec-ified" (i.e. may not satisfy its type spec) on exit:
+#[spec]
+fn two(#[unspec(out)] x: P, y: &mut Q) -> R;
+
+// Input `y` is unspecified on entry:
+#[spec]
+fn three(x: P, #[unspec(in)] y: &mut Q) -> R;
+
+// Input `y` is unspecified on both entry and exit:
+#[spec]
+fn four(x: P, #[unspec] y: &mut Q) -> R;
+
+// The output is unspecified on exit:
+#[spec]
+#[unspec(out)]
+fn five(x: P, y: &mut Q) -> R;
+
+// Default: all fields must satisfy their type specs:
+#[spec]
+struct Six {
+    pub a: T,
+    pub b: T,
+}
+
+// The field `b` is unspecified:
+#[spec]
+struct Seven {
+    pub a: T,
+    #[unspec]
+    pub b: T,
+}


### PR DESCRIPTION
- Reorganize specification syntax in `anodized-core` into a top-level module.
- Add shared helpers for parsing and removing attributes.
- Introduce parsed representations for `#[unspec]` and its arguments.
- Extend function and data specs with spec-boundary metadata.
- Add an `EmptySpec` type for items that do not support spec fields.
- Expose the `unspec` attribute through the `anodized` crate.
- Extend unit and top-level test coverage.