### PR TITLE
[anodized-core] refactor: unify instrumentation and spec embedding

### DIFF
--- a/crates/anodized-core/src/annotate.rs
+++ b/crates/anodized-core/src/annotate.rs
@@ -8,6 +8,7 @@ use syn::{
 use crate::{
     Capture, Condition, DataSpec, EmptySpec, FnSpec, InputSpecFlags, LoopSpec, LoopVariant,
     PostCondition,
+    instrument::patterns::{IdentGenerator, tame_pattern},
     qualifiers::FnQualifiers,
     syntax::{Keyword, SpecFields, UnspecArg, UnspecAttr, get_attr_input, remove_unique_attr},
 };
@@ -229,6 +230,7 @@ impl FnSpec {
         let span = raw_spec.span();
 
         let mut errors = MultiError::empty();
+        let mut id_gen = IdentGenerator::new();
         let mut qualifiers = FnQualifiers::empty();
         let mut requires: Vec<Condition> = vec![];
         let mut maintains: Vec<Condition> = vec![];
@@ -321,7 +323,7 @@ impl FnSpec {
                     ));
                 }
                 Keyword::Ensures => {
-                    if let Err(error) = parse_postconds(field, &mut ensures) {
+                    if let Err(error) = parse_postconds(&mut id_gen, field, &mut ensures) {
                         errors.add(error);
                     }
                 }
@@ -553,7 +555,11 @@ fn parse_conditions(field: FieldValue, conditions: &mut Vec<Condition>) -> Resul
     Ok(())
 }
 
-fn parse_postconds(field: FieldValue, postconds: &mut Vec<PostCondition>) -> Result<()> {
+fn parse_postconds(
+    id_gen: &mut IdentGenerator,
+    field: FieldValue,
+    postconds: &mut Vec<PostCondition>,
+) -> Result<()> {
     let cfg_attr = find_cfg_attribute(&field.attrs)?;
     let cfg: Option<Meta> = if let Some(attr) = cfg_attr {
         Some(attr.parse_args()?)
@@ -572,17 +578,18 @@ fn parse_postconds(field: FieldValue, postconds: &mut Vec<PostCondition>) -> Res
                 ));
             }
             let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
+            let tame_pat = tame_pattern(id_gen, pat)?;
             if let Expr::Array(array) = *closure.body {
                 for expr in array.elems {
                     postconds.push(PostCondition {
-                        pat: Some(pat.clone()),
+                        pat: Some(tame_pat.clone()),
                         expr,
                         cfg: cfg.clone(),
                     });
                 }
             } else {
                 postconds.push(PostCondition {
-                    pat: Some(pat),
+                    pat: Some(tame_pat),
                     expr: *closure.body,
                     cfg: cfg.clone(),
                 });
@@ -598,8 +605,9 @@ fn parse_postconds(field: FieldValue, postconds: &mut Vec<PostCondition>) -> Res
                         ));
                     }
                     let (pat, _) = closure.inputs.pop().unwrap().into_tuple();
+                    let tame_pat = tame_pattern(id_gen, pat)?;
                     postconds.push(PostCondition {
-                        pat: Some(pat),
+                        pat: Some(tame_pat),
                         expr: *closure.body,
                         cfg: cfg.clone(),
                     });

--- a/crates/anodized-core/src/annotate_tests.rs
+++ b/crates/anodized-core/src/annotate_tests.rs
@@ -1,3 +1,4 @@
+use crate::instrument::patterns::TamePat;
 use crate::test_util::{
     SpecItemEnum, SpecItemFn, SpecItemStruct, assert_spec_eq, assert_tokens_eq,
 };
@@ -333,7 +334,10 @@ fn all_clauses() {
         }],
         captures: vec![],
         ensures: vec![PostCondition {
-            pat: Some(parse_quote! { z }),
+            pat: Some(TamePat::Invertible(
+                parse_quote! { z },
+                Box::new(parse_quote! { z }),
+            )),
             expr: parse_quote! { z >= x },
             cfg: None,
         }],
@@ -433,7 +437,10 @@ fn array_of_conditions() {
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { retval }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { retval },
+                    Box::new(parse_quote! { retval }),
+                )),
                 expr: parse_quote! { retval.is_some() },
                 cfg: None,
             },
@@ -461,7 +468,10 @@ fn ensures_with_explicit_closure() {
         maintains: vec![],
         captures: vec![],
         ensures: vec![PostCondition {
-            pat: Some(parse_quote! { result }),
+            pat: Some(TamePat::Invertible(
+                parse_quote! { result },
+                Box::new(parse_quote! { result }),
+            )),
             expr: parse_quote! { result.is_ok() || result.unwrap_err().kind() == ErrorKind::NotFound },
             cfg: None,
         }],
@@ -506,7 +516,10 @@ fn multiple_clauses_of_same_flavor() {
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { output }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { output },
+                    Box::new(parse_quote! { output }),
+                )),
                 expr: parse_quote! { output.len() >= y.len() },
                 cfg: None,
             },
@@ -566,7 +579,10 @@ fn mixed_single_and_array_clauses() {
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { val }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { val },
+                    Box::new(parse_quote! { val }),
+                )),
                 expr: parse_quote! { output.starts_with(z) },
                 cfg: None,
             },
@@ -576,12 +592,18 @@ fn mixed_single_and_array_clauses() {
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { output }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { output },
+                    Box::new(parse_quote! { output }),
+                )),
                 expr: parse_quote! { output >= x },
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { output }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { output },
+                    Box::new(parse_quote! { output }),
+                )),
                 expr: parse_quote! { x != z },
                 cfg: None,
             },
@@ -718,12 +740,18 @@ fn binds_pattern() {
         captures: vec![],
         ensures: vec![
             PostCondition {
-                pat: Some(parse_quote! { (a, b) }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { (a, b) },
+                    Box::new(parse_quote! { (a, b) }),
+                )),
                 expr: parse_quote! { a <= b },
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { (a, b) }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { (a, b) },
+                    Box::new(parse_quote! { (a, b) }),
+                )),
                 expr: parse_quote! { (a, b) == pair || (b, a) == pair },
                 cfg: None,
             },
@@ -799,12 +827,18 @@ fn rename_return_value() {
         captures: vec![],
         ensures: vec![
             PostCondition {
-                pat: Some(parse_quote! { result }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { result },
+                    Box::new(parse_quote! { result }),
+                )),
                 expr: parse_quote! { result > output },
                 cfg: None,
             },
             PostCondition {
-                pat: Some(parse_quote! { result }),
+                pat: Some(TamePat::Invertible(
+                    parse_quote! { result },
+                    Box::new(parse_quote! { result }),
+                )),
                 expr: parse_quote! { result % 2 == 0 },
                 cfg: None,
             },
@@ -967,7 +1001,10 @@ fn captures_with_all_clauses() {
             expr: parse_quote! { value },
         }],
         ensures: vec![PostCondition {
-            pat: Some(parse_quote! { result }),
+            pat: Some(TamePat::Invertible(
+                parse_quote! { result },
+                Box::new(parse_quote! { result }),
+            )),
             expr: parse_quote! { result > old_val },
             cfg: None,
         }],

--- a/crates/anodized-core/src/instrument.rs
+++ b/crates/anodized-core/src/instrument.rs
@@ -108,7 +108,7 @@ Instead, you likely need to place a `#[spec]` attribute on an enclosing trait or
                     &spec.maintains,
                     &spec.captures,
                     &spec.ensures,
-                )?),
+                )),
             };
 
             spec_qualifiers_const.to_tokens(&mut tokens);

--- a/crates/anodized-core/src/instrument/data_tests.rs
+++ b/crates/anodized-core/src/instrument/data_tests.rs
@@ -40,9 +40,10 @@ fn embed_spec_item_struct() {
             'LT_1: 'LT_2,
         {
             fn __anodized_data_maintains(&self) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                __anodized_pre
             }
         }
     };
@@ -90,9 +91,10 @@ fn embed_spec_item_enum() {
         {
             fn __anodized_data_maintains(&self) -> bool {
                 use ENUM::*;
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                __anodized_pre
             }
         }
     };

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -191,15 +191,22 @@ impl Mode {
 
         for capture in captures {
             patterns.push(&capture.pat);
-            values.push(&capture.expr);
+            let capture_eval = build_capture_eval(&capture.expr);
+            values.push(capture_eval);
         }
 
         let output_ident = Pat::Path(parse_quote! { __anodized_output });
         patterns.push(&output_ident);
         let body_eval = Expr::Call(parse_quote! { ::anodized::__::eval_once(|| #body) });
-        values.push(&body_eval);
+        values.push(body_eval);
 
-        statements.push(parse_quote! { let (#(#patterns,)*) = (#(#values,)*); });
+        let binding = if patterns.len() > 1 {
+            parse_quote! { let (#(#patterns,)*) = (#(#values,)*); }
+        } else {
+            parse_quote! { let #(#patterns)* = #(#values)*; }
+        };
+
+        statements.push(binding);
     }
 
     pub fn emit_postcondition_checks(

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -221,24 +221,24 @@ impl CheckSettings {
         }];
         for precondition in &spec.requires {
             let eval = build_cond_eval(&precondition.expr);
-            let check = self.build_cond_check(
+            let instrumented_eval = self.instrument_cond_eval(
                 "precondition failed: {}",
                 &precondition.cfg,
                 &eval,
                 &precondition.expr.to_token_stream().to_string(),
             );
-            let check = self.build_precond_check(&check);
+            let check = self.build_precond_check(&instrumented_eval);
             precond_checks.push(check);
         }
         for preinvariant in &spec.maintains {
             let eval = build_cond_eval(&preinvariant.expr);
-            let check = self.build_cond_check(
+            let instrumented_eval = self.instrument_cond_eval(
                 "preinvariant failed: {}",
                 &preinvariant.cfg,
                 &eval,
                 &preinvariant.expr.to_token_stream().to_string(),
             );
-            let check = self.build_precond_check(&check);
+            let check = self.build_precond_check(&instrumented_eval);
             precond_checks.push(check);
         }
 
@@ -276,13 +276,13 @@ impl CheckSettings {
         }];
         for postinvariant in &spec.maintains {
             let eval = build_cond_eval(&postinvariant.expr);
-            let check = self.build_cond_check(
+            let instrumented_eval = self.instrument_cond_eval(
                 "postinvariant failed: {}",
                 &postinvariant.cfg,
                 &eval,
                 &postinvariant.expr.to_token_stream().to_string(),
             );
-            let check = self.build_postcond_check(&None, &check);
+            let check = self.build_postcond_check(&None, &instrumented_eval);
             postcond_checks.push(check);
         }
         for postcondition in &spec.ensures {
@@ -292,13 +292,13 @@ impl CheckSettings {
                 None
             };
             let eval = build_cond_eval(&postcondition.expr);
-            let check = self.build_cond_check(
+            let instrumented_eval = self.instrument_cond_eval(
                 "postcondition failed: {}",
                 &postcondition.cfg,
                 &eval,
                 &postcondition.expr.to_token_stream().to_string(),
             );
-            let check = self.build_postcond_check(&tame_pat, &check);
+            let check = self.build_postcond_check(&tame_pat, &instrumented_eval);
             postcond_checks.push(check);
         }
 
@@ -335,13 +335,13 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check(&self, check: &Expr) -> Stmt {
+    fn build_precond_check(&self, expr: &Expr) -> Stmt {
         parse_quote! {
-            let __anodized_pre = __anodized_pre & #check;
+            let __anodized_pre = __anodized_pre & #expr;
         }
     }
 
-    fn build_postcond_check(&self, tame_pat: &Option<TamePat>, check: &Expr) -> Stmt {
+    fn build_postcond_check(&self, tame_pat: &Option<TamePat>, expr: &Expr) -> Stmt {
         match tame_pat {
             Some(TamePat::Borrowing(brw_pat)) => {
                 parse_quote! {
@@ -350,7 +350,7 @@ impl CheckSettings {
                             ::anodized::__::coerce_input(
                                 #[allow(unused)] |#brw_pat| (), &__anodized_output);
                             let #brw_pat = __anodized_output else { unreachable!() };
-                            (__anodized_post & #check, __anodized_output)
+                            (__anodized_post & #expr, __anodized_output)
                         },
                         __anodized_output,
                     );
@@ -359,20 +359,20 @@ impl CheckSettings {
             Some(TamePat::Invertible(inv_pat, inv_expr)) => {
                 parse_quote! {
                     let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
-                        |#inv_pat| (__anodized_post & #check, #inv_expr),
+                        |#inv_pat| (__anodized_post & #expr, #inv_expr),
                         __anodized_output,
                     );
                 }
             }
             None => {
                 parse_quote! {
-                    let __anodized_post = __anodized_post & #check;
+                    let __anodized_post = __anodized_post & #expr;
                 }
             }
         }
     }
 
-    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
+    fn instrument_cond_eval(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
         let span = cond.span();
 
         let guard: Option<Expr> = if self.does_print || self.does_panic.is_some() {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -9,6 +9,7 @@ use syn::{
     parse::{Parse, Result},
     parse_quote, parse_quote_spanned,
     spanned::Spanned,
+    token::Brace,
 };
 
 use crate::{
@@ -124,7 +125,19 @@ impl Mode {
     }
 
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
-        let mut statements: Vec<Stmt> = vec![];
+        let mut stmts: Vec<Stmt> = vec![];
+        Self::emit_precondition_checks(requires, maintains, &mut stmts);
+        Block {
+            brace_token: Brace(Span::mixed_site()),
+            stmts,
+        }
+    }
+
+    pub fn emit_precondition_checks(
+        requires: &[Condition],
+        maintains: &[Condition],
+        statements: &mut Vec<Stmt>,
+    ) {
         let mut clauses: Vec<Expr> = vec![];
 
         for condition in requires.iter().chain(maintains) {
@@ -139,12 +152,12 @@ impl Mode {
             clauses.push(parse_quote!(true));
         }
 
-        parse_quote! {
-            {
-                #(#statements)*
+        statements.push(Stmt::Expr(
+            parse_quote! {
                 #(#clauses)&&*
-            }
-        }
+            },
+            None,
+        ));
     }
 
     pub fn build_postcondition_fn_body(
@@ -152,7 +165,20 @@ impl Mode {
         captures: &[Capture],
         ensures: &[PostCondition],
     ) -> Result<Block> {
-        let mut statements: Vec<Stmt> = vec![];
+        let mut stmts: Vec<Stmt> = vec![];
+        Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts);
+        Ok(Block {
+            brace_token: Brace(Span::mixed_site()),
+            stmts,
+        })
+    }
+
+    pub fn emit_postcondition_checks(
+        maintains: &[Condition],
+        captures: &[Capture],
+        ensures: &[PostCondition],
+        statements: &mut Vec<Stmt>,
+    ) {
         let mut clauses: Vec<Expr> = vec![];
 
         for condition in maintains {
@@ -190,12 +216,12 @@ impl Mode {
             clauses.push(parse_quote!(true));
         }
 
-        Ok(parse_quote! {
-            {
-                #(#statements)*
+        statements.push(Stmt::Expr(
+            parse_quote! {
                 #(#clauses)&&*
-            }
-        })
+            },
+            None,
+        ));
     }
 }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -2,7 +2,7 @@
 #[path = "fns_tests.rs"]
 mod fns_tests;
 
-use quote::{ToTokens, quote};
+use quote::ToTokens;
 use syn::{
     Attribute, Block, Expr, Ident, Meta, Pat, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
@@ -136,11 +136,10 @@ impl Mode {
         ensures: &[PostCondition],
     ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        emit_capture_binding(
-            captures,
-            &parse_quote! { { __anodized_output } },
-            &mut stmts,
-        );
+        let output_eval: Expr = parse_quote! {
+            ::anodized::__::eval_once(|| { __anodized_output })
+        };
+        emit_capture_binding(captures, output_eval, &mut stmts);
         emit_postcondition_checks(maintains, ensures, &mut stmts, None);
         parse_quote! {
             {
@@ -162,42 +161,44 @@ impl CheckSettings {
         // The identifier for the return value binding.
         let output_ident: Pat = parse_quote!(__anodized_output);
 
+        let (output_expr, precond_fail_action, postcond_fail_action) =
+            if let Some(ref panic_settings) = self.does_panic
+                && panic_settings.has_try_fn
+            {
+                (
+                    parse_quote! { Ok(#output_ident) },
+                    Some(parse_quote! { return ::anodized::result::pre_err(); }),
+                    Some(parse_quote! { return ::anodized::result::post_err(#output_ident); }),
+                )
+            } else {
+                (
+                    parse_quote! { #output_ident },
+                    self.build_fail_action("precondition failed"),
+                    self.build_fail_action("postcondition failed"),
+                )
+            };
+
+        let instrument_eval = |msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str| {
+            self.instrument_cond_eval(msg, cfg, cond, repr)
+        };
+
+        let mut stmts: Vec<Stmt> = vec![];
+
         // Generate precondition checks.
-        let mut precond_checks: Vec<Stmt> = vec![parse_quote! {
-            let __anodized_pre = true;
-        }];
-        for precondition in &spec.requires {
-            let eval = build_cond_eval(&precondition.expr);
-            let instrumented_eval = self.instrument_cond_eval(
-                "precondition failed: {}",
-                &precondition.cfg,
-                &eval,
-                &precondition.expr.to_token_stream().to_string(),
-            );
-            let check = build_precond_check(&instrumented_eval);
-            precond_checks.push(check);
-        }
-        for preinvariant in &spec.maintains {
-            let eval = build_cond_eval(&preinvariant.expr);
-            let instrumented_eval = self.instrument_cond_eval(
-                "preinvariant failed: {}",
-                &preinvariant.cfg,
-                &eval,
-                &preinvariant.expr.to_token_stream().to_string(),
-            );
-            let check = build_precond_check(&instrumented_eval);
-            precond_checks.push(check);
-        }
+        emit_precondition_checks(
+            &spec.requires,
+            &spec.maintains,
+            &mut stmts,
+            Some(&instrument_eval),
+        );
+        stmts.push(parse_quote! {
+            if !__anodized_pre {
+                #precond_fail_action
+            }
+        });
 
-        // Bind capture values and function output in a single tuple assignment.
-        // This ensures captured values are inaccessible to the body.
-        let patterns = spec
-            .captures
-            .iter()
-            .map(|cb| &cb.pat)
-            .chain(std::iter::once(&output_ident));
-
-        let body_expr: Expr = if is_async {
+        // Generate the binding for captures and the return value.
+        let output_eval: Expr = if is_async {
             parse_quote! {
                 ::anodized::__::eval_once(async || #return_type #original_body).await
             }
@@ -206,73 +207,26 @@ impl CheckSettings {
                 ::anodized::__::eval_once(|| #return_type #original_body)
             }
         };
-        let values = spec
-            .captures
-            .iter()
-            .map(|cb| build_capture_eval(&cb.expr))
-            .chain(std::iter::once(body_expr));
-
-        let captures_and_output = quote! {
-            let (#(#patterns),*) = (#(#values),*);
-        };
+        emit_capture_binding(&spec.captures, output_eval, &mut stmts);
 
         // Generate postcondition checks.
-        let mut postcond_checks: Vec<Stmt> = vec![parse_quote! {
-            let __anodized_post = true;
-        }];
-        for postinvariant in &spec.maintains {
-            let eval = build_cond_eval(&postinvariant.expr);
-            let instrumented_eval = self.instrument_cond_eval(
-                "postinvariant failed: {}",
-                &postinvariant.cfg,
-                &eval,
-                &postinvariant.expr.to_token_stream().to_string(),
-            );
-            let check = build_postcond_check(&None, &instrumented_eval);
-            postcond_checks.push(check);
-        }
-        for postcondition in &spec.ensures {
-            let eval = build_cond_eval(&postcondition.expr);
-            let instrumented_eval = self.instrument_cond_eval(
-                "postcondition failed: {}",
-                &postcondition.cfg,
-                &eval,
-                &postcondition.expr.to_token_stream().to_string(),
-            );
-            let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
-            postcond_checks.push(check);
-        }
-
-        let (output_expr, precond_fail_action, postcond_fail_action) =
-            if let Some(ref panic_settings) = self.does_panic
-                && panic_settings.has_try_fn
-            {
-                (
-                    quote! { Ok(#output_ident) },
-                    Some(parse_quote! { return ::anodized::result::pre_err(); }),
-                    Some(parse_quote! { return ::anodized::result::post_err(#output_ident); }),
-                )
-            } else {
-                (
-                    quote! { #output_ident },
-                    self.build_fail_action("precondition failed"),
-                    self.build_fail_action("postcondition failed"),
-                )
-            };
-
-        Ok(parse_quote! {
-            {
-                #(#precond_checks)*
-                if !__anodized_pre {
-                    #precond_fail_action
-                }
-                #captures_and_output
-                #(#postcond_checks)*
-                if !__anodized_post {
-                    #postcond_fail_action
-                }
-                #output_expr
+        emit_postcondition_checks(
+            &spec.maintains,
+            &spec.ensures,
+            &mut stmts,
+            Some(&instrument_eval),
+        );
+        stmts.push(parse_quote! {
+            if !__anodized_post {
+                #postcond_fail_action
             }
+        });
+
+        stmts.push(Stmt::Expr(output_expr, None));
+
+        Ok(Block {
+            brace_token: original_body.brace_token,
+            stmts,
         })
     }
 
@@ -312,7 +266,7 @@ fn emit_precondition_checks(
     requires: &[Condition],
     maintains: &[Condition],
     statements: &mut Vec<Stmt>,
-    maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+    maybe_instrument_eval: Option<&dyn Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
 ) {
     statements.push(parse_quote! {
         let __anodized_pre = true;
@@ -343,7 +297,7 @@ fn emit_precondition_checks(
     }
 }
 
-fn emit_capture_binding(captures: &[Capture], body: &Block, statements: &mut Vec<Stmt>) {
+fn emit_capture_binding(captures: &[Capture], output_eval: Expr, statements: &mut Vec<Stmt>) {
     let mut patterns = vec![];
     let mut values = vec![];
 
@@ -355,8 +309,7 @@ fn emit_capture_binding(captures: &[Capture], body: &Block, statements: &mut Vec
 
     let output_ident = Pat::Path(parse_quote! { __anodized_output });
     patterns.push(&output_ident);
-    let body_eval = Expr::Call(parse_quote! { ::anodized::__::eval_once(|| #body) });
-    values.push(body_eval);
+    values.push(output_eval);
 
     let binding = if patterns.len() > 1 {
         parse_quote! { let (#(#patterns,)*) = (#(#values,)*); }
@@ -371,7 +324,7 @@ fn emit_postcondition_checks(
     maintains: &[Condition],
     ensures: &[PostCondition],
     statements: &mut Vec<Stmt>,
-    maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+    maybe_instrument_eval: Option<&dyn Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
 ) {
     statements.push(parse_quote! {
         let __anodized_post = true;

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -121,8 +121,8 @@ impl Mode {
 
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        emit_precondition_checks(requires, maintains, &mut stmts, |_, _, cond_eval, _| {
-            cond_eval.clone()
+        emit_precondition_checks(requires, maintains, &mut stmts, |eval, _, _, _| {
+            eval.clone()
         });
         parse_quote! {
             {
@@ -142,9 +142,7 @@ impl Mode {
             ::anodized::__::eval_once(|| { __anodized_output })
         };
         emit_captures_and_output_binding(captures, output_eval, &mut stmts);
-        emit_postcondition_checks(maintains, ensures, &mut stmts, |_, _, cond_eval, _| {
-            cond_eval.clone()
-        });
+        emit_postcondition_checks(maintains, ensures, &mut stmts, |eval, _, _, _| eval.clone());
         parse_quote! {
             {
                 #(#stmts)*
@@ -186,7 +184,7 @@ impl CheckSettings {
             &spec.requires,
             &spec.maintains,
             &mut stmts,
-            |msg, cfg, cond, repr| self.instrument_cond_eval(msg, cfg, cond, repr),
+            |eval, cfg, msg, repr| self.instrument_cond_eval(eval, cfg, msg, repr),
         );
         stmts.push(parse_quote! {
             if !__anodized_pre {
@@ -211,7 +209,7 @@ impl CheckSettings {
             &spec.maintains,
             &spec.ensures,
             &mut stmts,
-            |msg, cfg, cond, repr| self.instrument_cond_eval(msg, cfg, cond, repr),
+            |eval, cfg, msg, repr| self.instrument_cond_eval(eval, cfg, msg, repr),
         );
         stmts.push(parse_quote! {
             if !__anodized_post {
@@ -227,7 +225,13 @@ impl CheckSettings {
         })
     }
 
-    fn instrument_cond_eval(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
+    fn instrument_cond_eval(
+        &self,
+        cond: &Expr,
+        cfg: &Option<Meta>,
+        msg: &str,
+        repr: &Expr,
+    ) -> Expr {
         let span = cond.span();
 
         let guard: Option<Expr> = if self.does_print || self.does_panic.is_some() {
@@ -237,7 +241,8 @@ impl CheckSettings {
         };
 
         let printer: Option<Expr> = if self.does_print {
-            Some(parse_quote! { eprintln!(#msg, #repr) != () })
+            let repr_str = repr.to_token_stream().to_string();
+            Some(parse_quote! { eprintln!(#msg, #repr_str) != () })
         } else {
             None
         };
@@ -259,8 +264,8 @@ impl CheckSettings {
     }
 }
 
-trait FnInstrumentEval: Fn(&str, &Option<Meta>, &Expr, &str) -> Expr {}
-impl<F> FnInstrumentEval for F where F: Fn(&str, &Option<Meta>, &Expr, &str) -> Expr {}
+trait FnInstrumentEval: Fn(&Expr, &Option<Meta>, &str, &Expr) -> Expr {}
+impl<F: Fn(&Expr, &Option<Meta>, &str, &Expr) -> Expr> FnInstrumentEval for F {}
 
 fn emit_precondition_checks(
     requires: &[Condition],
@@ -274,18 +279,24 @@ fn emit_precondition_checks(
 
     for precondition in requires {
         let eval = build_cond_eval(&precondition.expr);
-        let repr = precondition.expr.to_token_stream().to_string();
-        let instrumented_eval =
-            instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr);
+        let instrumented_eval = instrument_eval(
+            &eval,
+            &precondition.cfg,
+            "precondition failed: {}",
+            &precondition.expr,
+        );
         let check = build_precond_check(&instrumented_eval);
         statements.push(check);
     }
 
     for preinvariant in maintains {
         let eval = build_cond_eval(&preinvariant.expr);
-        let repr = preinvariant.expr.to_token_stream().to_string();
-        let instrumented_eval =
-            instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr);
+        let instrumented_eval = instrument_eval(
+            &eval,
+            &preinvariant.cfg,
+            "preinvariant failed: {}",
+            &preinvariant.expr,
+        );
         let check = build_precond_check(&instrumented_eval);
         statements.push(check);
     }
@@ -330,18 +341,24 @@ fn emit_postcondition_checks(
 
     for postinvariant in maintains {
         let eval = build_cond_eval(&postinvariant.expr);
-        let repr = postinvariant.expr.to_token_stream().to_string();
-        let instrumented_eval =
-            instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr);
+        let instrumented_eval = instrument_eval(
+            &eval,
+            &postinvariant.cfg,
+            "postinvariant failed: {}",
+            &postinvariant.expr,
+        );
         let check = build_postcond_check(&None, &instrumented_eval);
         statements.push(check);
     }
 
     for postcondition in ensures {
         let eval = build_cond_eval(&postcondition.expr);
-        let repr = postcondition.expr.to_token_stream().to_string();
-        let instrumented_eval =
-            instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr);
+        let instrumented_eval = instrument_eval(
+            &eval,
+            &postcondition.cfg,
+            "postcondition failed: {}",
+            &postcondition.expr,
+        );
         let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
         statements.push(check);
     }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -12,10 +12,7 @@ use syn::{
 
 use crate::{
     Capture, Condition, FnSpec, PostCondition,
-    instrument::{
-        CheckSettings, Mode,
-        patterns::{IdentGenerator, TamePat, tame_pattern},
-    },
+    instrument::{CheckSettings, Mode, patterns::TamePat},
     qualifiers::FnQualifiers,
 };
 
@@ -187,17 +184,9 @@ impl Mode {
         }
 
         for postcondition in ensures {
-            let expr = &postcondition.expr;
-            let eval = if let Some(pat) = &postcondition.pat {
-                build_cond_eval(&parse_quote! {
-                    { let #pat = __anodized_output; #expr }
-                })
-            } else {
-                build_cond_eval(expr)
-            };
-            statements.push(parse_quote! {
-                let __anodized_post = __anodized_post & #eval;
-            });
+            let eval = build_cond_eval(&postcondition.expr);
+            let check = build_postcond_check(&postcondition.pat, &eval);
+            statements.push(check);
         }
     }
 }
@@ -267,7 +256,6 @@ impl CheckSettings {
             let (#(#patterns),*) = (#(#values),*);
         };
 
-        let mut id_gen = IdentGenerator::new();
         // Generate postcondition checks.
         let mut postcond_checks: Vec<Stmt> = vec![parse_quote! {
             let __anodized_post = true;
@@ -284,11 +272,6 @@ impl CheckSettings {
             postcond_checks.push(check);
         }
         for postcondition in &spec.ensures {
-            let tame_pat = if let Some(pat) = &postcondition.pat {
-                Some(tame_pattern(&mut id_gen, pat.clone())?)
-            } else {
-                None
-            };
             let eval = build_cond_eval(&postcondition.expr);
             let instrumented_eval = self.instrument_cond_eval(
                 "postcondition failed: {}",
@@ -296,7 +279,7 @@ impl CheckSettings {
                 &eval,
                 &postcondition.expr.to_token_stream().to_string(),
             );
-            let check = build_postcond_check(&tame_pat, &instrumented_eval);
+            let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
             postcond_checks.push(check);
         }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -134,7 +134,7 @@ impl Mode {
         requires: &[Condition],
         maintains: &[Condition],
         statements: &mut Vec<Stmt>,
-        maybe_instrument_eval: Option<&impl Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+        maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
     ) {
         statements.push(parse_quote! {
             let __anodized_pre = true;
@@ -185,7 +185,7 @@ impl Mode {
         captures: &[Capture],
         ensures: &[PostCondition],
         statements: &mut Vec<Stmt>,
-        maybe_instrument_eval: Option<&impl Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+        maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
     ) {
         statements.push(parse_quote! {
             let __anodized_post = true;

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -224,6 +224,7 @@ impl CheckSettings {
                 "precondition failed: {}",
                 &precondition.cfg,
                 &precondition.expr,
+                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
             );
             precond_checks.push(check);
         }
@@ -232,6 +233,7 @@ impl CheckSettings {
                 "preinvariant failed: {}",
                 &preinvariant.cfg,
                 &preinvariant.expr,
+                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
             );
             precond_checks.push(check);
         }
@@ -274,6 +276,7 @@ impl CheckSettings {
                 &postinvariant.cfg,
                 &None,
                 &postinvariant.expr,
+                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
             );
             postcond_checks.push(check);
         }
@@ -288,6 +291,7 @@ impl CheckSettings {
                 &postcondition.cfg,
                 &tame_pat,
                 &postcondition.expr,
+                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
             );
             postcond_checks.push(check);
         }
@@ -325,25 +329,38 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check(&self, msg: &str, cfg: &Option<Meta>, expr: &Expr) -> Stmt {
+    fn build_precond_check<F>(
+        &self,
+        msg: &str,
+        cfg: &Option<Meta>,
+        expr: &Expr,
+        build_cond_check: F,
+    ) -> Stmt
+    where
+        F: Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+    {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        let check = self.build_cond_check(msg, cfg, eval, &repr);
+        let check = build_cond_check(msg, cfg, eval, &repr);
         parse_quote! {
             let __anodized_pre = __anodized_pre & #check;
         }
     }
 
-    fn build_postcond_check(
+    fn build_postcond_check<F>(
         &self,
         msg: &str,
         cfg: &Option<Meta>,
         tame_pat: &Option<TamePat>,
         expr: &Expr,
-    ) -> Stmt {
+        build_cond_check: F,
+    ) -> Stmt
+    where
+        F: Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+    {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        let check = self.build_cond_check(msg, cfg, eval, &repr);
+        let check = build_cond_check(msg, cfg, eval, &repr);
         match tame_pat {
             Some(TamePat::Borrowing(brw_pat)) => {
                 parse_quote! {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -220,21 +220,27 @@ impl CheckSettings {
             let __anodized_pre = true;
         }];
         for precondition in &spec.requires {
-            let check = self.build_precond_check(
-                "precondition failed: {}",
-                &precondition.cfg,
-                &precondition.expr,
-                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
-            );
+            let check =
+                self.build_precond_check(&precondition.cfg, &precondition.expr, |cond, cfg| {
+                    self.build_cond_check(
+                        "precondition failed: {}",
+                        cfg,
+                        cond,
+                        &precondition.expr.to_token_stream().to_string(),
+                    )
+                });
             precond_checks.push(check);
         }
         for preinvariant in &spec.maintains {
-            let check = self.build_precond_check(
-                "preinvariant failed: {}",
-                &preinvariant.cfg,
-                &preinvariant.expr,
-                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
-            );
+            let check =
+                self.build_precond_check(&preinvariant.cfg, &preinvariant.expr, |cond, cfg| {
+                    self.build_cond_check(
+                        "preinvariant failed: {}",
+                        cfg,
+                        cond,
+                        &preinvariant.expr.to_token_stream().to_string(),
+                    )
+                });
             precond_checks.push(check);
         }
 
@@ -272,11 +278,17 @@ impl CheckSettings {
         }];
         for postinvariant in &spec.maintains {
             let check = self.build_postcond_check(
-                "postinvariant failed: {}",
                 &postinvariant.cfg,
                 &None,
                 &postinvariant.expr,
-                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
+                |cond, cfg| {
+                    self.build_cond_check(
+                        "postinvariant failed: {}",
+                        cfg,
+                        cond,
+                        &postinvariant.expr.to_token_stream().to_string(),
+                    )
+                },
             );
             postcond_checks.push(check);
         }
@@ -287,11 +299,17 @@ impl CheckSettings {
                 None
             };
             let check = self.build_postcond_check(
-                "postcondition failed: {}",
                 &postcondition.cfg,
                 &tame_pat,
                 &postcondition.expr,
-                |msg, cfg, cond, repr| self.build_cond_check(msg, cfg, cond, repr),
+                |cond, cfg| {
+                    self.build_cond_check(
+                        "postcondition failed: {}",
+                        cfg,
+                        cond,
+                        &postcondition.expr.to_token_stream().to_string(),
+                    )
+                },
             );
             postcond_checks.push(check);
         }
@@ -329,32 +347,28 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check<F>(
+    fn build_precond_check(
         &self,
-        msg: &str,
         cfg: &Option<Meta>,
         expr: &Expr,
-        build_cond_check: impl Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+        build_cond_check: impl Fn(&Expr, &Option<Meta>) -> Expr,
     ) -> Stmt {
-        let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        let check = build_cond_check(msg, cfg, eval, &repr);
+        let check = build_cond_check(&eval, cfg);
         parse_quote! {
             let __anodized_pre = __anodized_pre & #check;
         }
     }
 
-    fn build_postcond_check<F>(
+    fn build_postcond_check(
         &self,
-        msg: &str,
         cfg: &Option<Meta>,
         tame_pat: &Option<TamePat>,
         expr: &Expr,
-        build_cond_check: impl Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+        build_cond_check: impl Fn(&Expr, &Option<Meta>) -> Expr,
     ) -> Stmt {
-        let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
-        let check = build_cond_check(msg, cfg, eval, &repr);
+        let check = build_cond_check(&eval, cfg);
         match tame_pat {
             Some(TamePat::Borrowing(brw_pat)) => {
                 parse_quote! {
@@ -385,7 +399,7 @@ impl CheckSettings {
         }
     }
 
-    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: Expr, repr: &str) -> Expr {
+    fn build_cond_check(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
         let span = cond.span();
 
         let guard: Option<Expr> = if self.does_print || self.does_panic.is_some() {
@@ -400,7 +414,7 @@ impl CheckSettings {
             None
         };
 
-        let maybe_exprs = [guard, Some(cond), printer];
+        let maybe_exprs = [guard.as_ref(), Some(cond), printer.as_ref()];
         let exprs = maybe_exprs.iter().flatten();
 
         if exprs.clone().count() > 1 {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -121,7 +121,7 @@ impl Mode {
 
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        Self::emit_precondition_checks(requires, maintains, &mut stmts);
+        Self::emit_precondition_checks(requires, maintains, &mut stmts, None);
         parse_quote! {
             {
                 #(#stmts)*
@@ -134,13 +134,33 @@ impl Mode {
         requires: &[Condition],
         maintains: &[Condition],
         statements: &mut Vec<Stmt>,
+        maybe_instrument_eval: Option<&impl Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
     ) {
         statements.push(parse_quote! {
             let __anodized_pre = true;
         });
-        for precondition in requires.iter().chain(maintains) {
+
+        for precondition in requires {
             let eval = build_cond_eval(&precondition.expr);
-            let check = build_precond_check(&eval);
+            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+                let repr = precondition.expr.to_token_stream().to_string();
+                instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr)
+            } else {
+                eval
+            };
+            let check = build_precond_check(&instrumented_eval);
+            statements.push(check);
+        }
+
+        for preinvariant in maintains {
+            let eval = build_cond_eval(&preinvariant.expr);
+            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+                let repr = preinvariant.expr.to_token_stream().to_string();
+                instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr)
+            } else {
+                eval
+            };
+            let check = build_precond_check(&instrumented_eval);
             statements.push(check);
         }
     }
@@ -151,7 +171,7 @@ impl Mode {
         ensures: &[PostCondition],
     ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts);
+        Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts, None);
         parse_quote! {
             {
                 #(#stmts)*
@@ -165,13 +185,21 @@ impl Mode {
         captures: &[Capture],
         ensures: &[PostCondition],
         statements: &mut Vec<Stmt>,
+        maybe_instrument_eval: Option<&impl Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
     ) {
         statements.push(parse_quote! {
             let __anodized_post = true;
         });
+
         for postinvariant in maintains {
             let eval = build_cond_eval(&postinvariant.expr);
-            let check = build_postcond_check(&None, &eval);
+            let instrumented_eval = if let Some(instrument_eval) = &maybe_instrument_eval {
+                let repr = postinvariant.expr.to_token_stream().to_string();
+                instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr)
+            } else {
+                eval
+            };
+            let check = build_postcond_check(&None, &instrumented_eval);
             statements.push(check);
         }
 
@@ -185,7 +213,13 @@ impl Mode {
 
         for postcondition in ensures {
             let eval = build_cond_eval(&postcondition.expr);
-            let check = build_postcond_check(&postcondition.pat, &eval);
+            let instrumented_eval = if let Some(instrument_eval) = &maybe_instrument_eval {
+                let repr = postcondition.expr.to_token_stream().to_string();
+                instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr)
+            } else {
+                eval
+            };
+            let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
             statements.push(check);
         }
     }

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -171,7 +171,12 @@ impl Mode {
         ensures: &[PostCondition],
     ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts, None);
+        Self::emit_capture_binding(
+            captures,
+            &parse_quote! { { __anodized_output } },
+            &mut stmts,
+        );
+        Self::emit_postcondition_checks(maintains, ensures, &mut stmts, None);
         parse_quote! {
             {
                 #(#stmts)*
@@ -180,9 +185,25 @@ impl Mode {
         }
     }
 
+    pub fn emit_capture_binding(captures: &[Capture], body: &Block, statements: &mut Vec<Stmt>) {
+        let mut patterns = vec![];
+        let mut values = vec![];
+
+        for capture in captures {
+            patterns.push(&capture.pat);
+            values.push(&capture.expr);
+        }
+
+        let output_ident = Pat::Path(parse_quote! { __anodized_output });
+        patterns.push(&output_ident);
+        let body_eval = Expr::Call(parse_quote! { ::anodized::__::eval_once(|| #body) });
+        values.push(&body_eval);
+
+        statements.push(parse_quote! { let (#(#patterns,)*) = (#(#values,)*); });
+    }
+
     pub fn emit_postcondition_checks(
         maintains: &[Condition],
-        captures: &[Capture],
         ensures: &[PostCondition],
         statements: &mut Vec<Stmt>,
         maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
@@ -193,7 +214,7 @@ impl Mode {
 
         for postinvariant in maintains {
             let eval = build_cond_eval(&postinvariant.expr);
-            let instrumented_eval = if let Some(instrument_eval) = &maybe_instrument_eval {
+            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
                 let repr = postinvariant.expr.to_token_stream().to_string();
                 instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr)
             } else {
@@ -203,17 +224,9 @@ impl Mode {
             statements.push(check);
         }
 
-        {
-            let patterns = captures.iter().map(|capture| &capture.pat);
-            let values = captures
-                .iter()
-                .map(|capture| build_capture_eval(&capture.expr));
-            statements.push(parse_quote! { let (#(#patterns),*) = (#(#values),*); });
-        }
-
         for postcondition in ensures {
             let eval = build_cond_eval(&postcondition.expr);
-            let instrumented_eval = if let Some(instrument_eval) = &maybe_instrument_eval {
+            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
                 let repr = postcondition.expr.to_token_stream().to_string();
                 instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr)
             } else {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -121,47 +121,12 @@ impl Mode {
 
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        Self::emit_precondition_checks(requires, maintains, &mut stmts, None);
+        emit_precondition_checks(requires, maintains, &mut stmts, None);
         parse_quote! {
             {
                 #(#stmts)*
                 __anodized_pre
             }
-        }
-    }
-
-    pub fn emit_precondition_checks(
-        requires: &[Condition],
-        maintains: &[Condition],
-        statements: &mut Vec<Stmt>,
-        maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
-    ) {
-        statements.push(parse_quote! {
-            let __anodized_pre = true;
-        });
-
-        for precondition in requires {
-            let eval = build_cond_eval(&precondition.expr);
-            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-                let repr = precondition.expr.to_token_stream().to_string();
-                instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr)
-            } else {
-                eval
-            };
-            let check = build_precond_check(&instrumented_eval);
-            statements.push(check);
-        }
-
-        for preinvariant in maintains {
-            let eval = build_cond_eval(&preinvariant.expr);
-            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-                let repr = preinvariant.expr.to_token_stream().to_string();
-                instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr)
-            } else {
-                eval
-            };
-            let check = build_precond_check(&instrumented_eval);
-            statements.push(check);
         }
     }
 
@@ -171,76 +136,17 @@ impl Mode {
         ensures: &[PostCondition],
     ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        Self::emit_capture_binding(
+        emit_capture_binding(
             captures,
             &parse_quote! { { __anodized_output } },
             &mut stmts,
         );
-        Self::emit_postcondition_checks(maintains, ensures, &mut stmts, None);
+        emit_postcondition_checks(maintains, ensures, &mut stmts, None);
         parse_quote! {
             {
                 #(#stmts)*
                 __anodized_post
             }
-        }
-    }
-
-    pub fn emit_capture_binding(captures: &[Capture], body: &Block, statements: &mut Vec<Stmt>) {
-        let mut patterns = vec![];
-        let mut values = vec![];
-
-        for capture in captures {
-            patterns.push(&capture.pat);
-            let capture_eval = build_capture_eval(&capture.expr);
-            values.push(capture_eval);
-        }
-
-        let output_ident = Pat::Path(parse_quote! { __anodized_output });
-        patterns.push(&output_ident);
-        let body_eval = Expr::Call(parse_quote! { ::anodized::__::eval_once(|| #body) });
-        values.push(body_eval);
-
-        let binding = if patterns.len() > 1 {
-            parse_quote! { let (#(#patterns,)*) = (#(#values,)*); }
-        } else {
-            parse_quote! { let #(#patterns)* = #(#values)*; }
-        };
-
-        statements.push(binding);
-    }
-
-    pub fn emit_postcondition_checks(
-        maintains: &[Condition],
-        ensures: &[PostCondition],
-        statements: &mut Vec<Stmt>,
-        maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
-    ) {
-        statements.push(parse_quote! {
-            let __anodized_post = true;
-        });
-
-        for postinvariant in maintains {
-            let eval = build_cond_eval(&postinvariant.expr);
-            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-                let repr = postinvariant.expr.to_token_stream().to_string();
-                instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr)
-            } else {
-                eval
-            };
-            let check = build_postcond_check(&None, &instrumented_eval);
-            statements.push(check);
-        }
-
-        for postcondition in ensures {
-            let eval = build_cond_eval(&postcondition.expr);
-            let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-                let repr = postcondition.expr.to_token_stream().to_string();
-                instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr)
-            } else {
-                eval
-            };
-            let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
-            statements.push(check);
         }
     }
 }
@@ -399,6 +305,100 @@ impl CheckSettings {
         self.does_panic
             .as_ref()
             .map(|_| parse_quote! { panic!(#message); })
+    }
+}
+
+fn emit_precondition_checks(
+    requires: &[Condition],
+    maintains: &[Condition],
+    statements: &mut Vec<Stmt>,
+    maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+) {
+    statements.push(parse_quote! {
+        let __anodized_pre = true;
+    });
+
+    for precondition in requires {
+        let eval = build_cond_eval(&precondition.expr);
+        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+            let repr = precondition.expr.to_token_stream().to_string();
+            instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr)
+        } else {
+            eval
+        };
+        let check = build_precond_check(&instrumented_eval);
+        statements.push(check);
+    }
+
+    for preinvariant in maintains {
+        let eval = build_cond_eval(&preinvariant.expr);
+        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+            let repr = preinvariant.expr.to_token_stream().to_string();
+            instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr)
+        } else {
+            eval
+        };
+        let check = build_precond_check(&instrumented_eval);
+        statements.push(check);
+    }
+}
+
+fn emit_capture_binding(captures: &[Capture], body: &Block, statements: &mut Vec<Stmt>) {
+    let mut patterns = vec![];
+    let mut values = vec![];
+
+    for capture in captures {
+        patterns.push(&capture.pat);
+        let capture_eval = build_capture_eval(&capture.expr);
+        values.push(capture_eval);
+    }
+
+    let output_ident = Pat::Path(parse_quote! { __anodized_output });
+    patterns.push(&output_ident);
+    let body_eval = Expr::Call(parse_quote! { ::anodized::__::eval_once(|| #body) });
+    values.push(body_eval);
+
+    let binding = if patterns.len() > 1 {
+        parse_quote! { let (#(#patterns,)*) = (#(#values,)*); }
+    } else {
+        parse_quote! { let #(#patterns)* = #(#values)*; }
+    };
+
+    statements.push(binding);
+}
+
+fn emit_postcondition_checks(
+    maintains: &[Condition],
+    ensures: &[PostCondition],
+    statements: &mut Vec<Stmt>,
+    maybe_instrument_eval: Option<fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+) {
+    statements.push(parse_quote! {
+        let __anodized_post = true;
+    });
+
+    for postinvariant in maintains {
+        let eval = build_cond_eval(&postinvariant.expr);
+        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+            let repr = postinvariant.expr.to_token_stream().to_string();
+            instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr)
+        } else {
+            eval
+        };
+        let check = build_postcond_check(&None, &instrumented_eval);
+        statements.push(check);
+    }
+
+    for postcondition in ensures {
+        let eval = build_cond_eval(&postcondition.expr);
+        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
+            let repr = postcondition.expr.to_token_stream().to_string();
+            instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr)
+        } else {
+            eval
+        };
+        let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
+        statements.push(check);
     }
 }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -141,11 +141,10 @@ impl Mode {
         statements.push(parse_quote! {
             let __anodized_pre = true;
         });
-        for condition in requires.iter().chain(maintains) {
-            let eval = build_cond_eval(&condition.expr);
-            statements.push(parse_quote! {
-                let __anodized_pre = __anodized_pre & #eval;
-            });
+        for precondition in requires.iter().chain(maintains) {
+            let eval = build_cond_eval(&precondition.expr);
+            let check = build_precond_check(&eval);
+            statements.push(check);
         }
     }
 
@@ -173,11 +172,10 @@ impl Mode {
         statements.push(parse_quote! {
             let __anodized_post = true;
         });
-        for condition in maintains {
-            let eval = build_cond_eval(&condition.expr);
-            statements.push(parse_quote! {
-                let __anodized_post = #eval;
-            });
+        for postinvariant in maintains {
+            let eval = build_cond_eval(&postinvariant.expr);
+            let check = build_postcond_check(&None, &eval);
+            statements.push(check);
         }
 
         {
@@ -188,9 +186,9 @@ impl Mode {
             statements.push(parse_quote! { let (#(#patterns),*) = (#(#values),*); });
         }
 
-        for postcond in ensures {
-            let expr = &postcond.expr;
-            let eval = if let Some(pat) = &postcond.pat {
+        for postcondition in ensures {
+            let expr = &postcondition.expr;
+            let eval = if let Some(pat) = &postcondition.pat {
                 build_cond_eval(&parse_quote! {
                     { let #pat = __anodized_output; #expr }
                 })
@@ -227,7 +225,7 @@ impl CheckSettings {
                 &eval,
                 &precondition.expr.to_token_stream().to_string(),
             );
-            let check = self.build_precond_check(&instrumented_eval);
+            let check = build_precond_check(&instrumented_eval);
             precond_checks.push(check);
         }
         for preinvariant in &spec.maintains {
@@ -238,7 +236,7 @@ impl CheckSettings {
                 &eval,
                 &preinvariant.expr.to_token_stream().to_string(),
             );
-            let check = self.build_precond_check(&instrumented_eval);
+            let check = build_precond_check(&instrumented_eval);
             precond_checks.push(check);
         }
 
@@ -282,7 +280,7 @@ impl CheckSettings {
                 &eval,
                 &postinvariant.expr.to_token_stream().to_string(),
             );
-            let check = self.build_postcond_check(&None, &instrumented_eval);
+            let check = build_postcond_check(&None, &instrumented_eval);
             postcond_checks.push(check);
         }
         for postcondition in &spec.ensures {
@@ -298,7 +296,7 @@ impl CheckSettings {
                 &eval,
                 &postcondition.expr.to_token_stream().to_string(),
             );
-            let check = self.build_postcond_check(&tame_pat, &instrumented_eval);
+            let check = build_postcond_check(&tame_pat, &instrumented_eval);
             postcond_checks.push(check);
         }
 
@@ -333,43 +331,6 @@ impl CheckSettings {
                 #output_expr
             }
         })
-    }
-
-    fn build_precond_check(&self, expr: &Expr) -> Stmt {
-        parse_quote! {
-            let __anodized_pre = __anodized_pre & #expr;
-        }
-    }
-
-    fn build_postcond_check(&self, tame_pat: &Option<TamePat>, expr: &Expr) -> Stmt {
-        match tame_pat {
-            Some(TamePat::Borrowing(brw_pat)) => {
-                parse_quote! {
-                    let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
-                        |__anodized_output| {
-                            ::anodized::__::coerce_input(
-                                #[allow(unused)] |#brw_pat| (), &__anodized_output);
-                            let #brw_pat = __anodized_output else { unreachable!() };
-                            (__anodized_post & #expr, __anodized_output)
-                        },
-                        __anodized_output,
-                    );
-                }
-            }
-            Some(TamePat::Invertible(inv_pat, inv_expr)) => {
-                parse_quote! {
-                    let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
-                        |#inv_pat| (__anodized_post & #expr, #inv_expr),
-                        __anodized_output,
-                    );
-                }
-            }
-            None => {
-                parse_quote! {
-                    let __anodized_post = __anodized_post & #expr;
-                }
-            }
-        }
     }
 
     fn instrument_cond_eval(&self, msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str) -> Expr {
@@ -411,6 +372,43 @@ fn build_cond_eval(expr: &Expr) -> Expr {
 
 fn build_capture_eval(expr: &Expr) -> Expr {
     parse_quote! { ::anodized::__::eval(|| #expr) }
+}
+
+fn build_precond_check(expr: &Expr) -> Stmt {
+    parse_quote! {
+        let __anodized_pre = __anodized_pre & #expr;
+    }
+}
+
+fn build_postcond_check(tame_pat: &Option<TamePat>, expr: &Expr) -> Stmt {
+    match tame_pat {
+        Some(TamePat::Borrowing(brw_pat)) => {
+            parse_quote! {
+                let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                    |__anodized_output| {
+                        ::anodized::__::coerce_input(
+                            #[allow(unused)] |#brw_pat| (), &__anodized_output);
+                        let #brw_pat = __anodized_output else { unreachable!() };
+                        (__anodized_post & #expr, __anodized_output)
+                    },
+                    __anodized_output,
+                );
+            }
+        }
+        Some(TamePat::Invertible(inv_pat, inv_expr)) => {
+            parse_quote! {
+                let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                    |#inv_pat| (__anodized_post & #expr, #inv_expr),
+                    __anodized_output,
+                );
+            }
+        }
+        None => {
+            parse_quote! {
+                let __anodized_post = __anodized_post & #expr;
+            }
+        }
+    }
 }
 
 pub(crate) fn make_try_fn_ident(ident: &Ident) -> Ident {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -2,14 +2,12 @@
 #[path = "fns_tests.rs"]
 mod fns_tests;
 
-use proc_macro2::Span;
 use quote::{ToTokens, quote};
 use syn::{
     Attribute, Block, Expr, Ident, Meta, Pat, Path, ReturnType, Signature, Stmt, Type,
     parse::{Parse, Result},
     parse_quote, parse_quote_spanned,
     spanned::Spanned,
-    token::Brace,
 };
 
 use crate::{
@@ -127,9 +125,11 @@ impl Mode {
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
         Self::emit_precondition_checks(requires, maintains, &mut stmts);
-        Block {
-            brace_token: Brace(Span::mixed_site()),
-            stmts,
+        parse_quote! {
+            {
+                #(#stmts)*
+                __anodized_pre
+            }
         }
     }
 
@@ -138,26 +138,15 @@ impl Mode {
         maintains: &[Condition],
         statements: &mut Vec<Stmt>,
     ) {
-        let mut clauses: Vec<Expr> = vec![];
-
+        statements.push(parse_quote! {
+            let __anodized_pre = true;
+        });
         for condition in requires.iter().chain(maintains) {
-            let i = clauses.len();
-            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let eval = build_cond_eval(&condition.expr);
-            statements.push(parse_quote! { let #name = #eval; });
-            clauses.push(parse_quote! { #name });
+            statements.push(parse_quote! {
+                let __anodized_pre = __anodized_pre & #eval;
+            });
         }
-
-        if clauses.is_empty() {
-            clauses.push(parse_quote!(true));
-        }
-
-        statements.push(Stmt::Expr(
-            parse_quote! {
-                #(#clauses)&&*
-            },
-            None,
-        ));
     }
 
     pub fn build_postcondition_fn_body(
@@ -167,9 +156,11 @@ impl Mode {
     ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
         Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts);
-        Block {
-            brace_token: Brace(Span::mixed_site()),
-            stmts,
+        parse_quote! {
+            {
+                #(#stmts)*
+                __anodized_post
+            }
         }
     }
 
@@ -179,14 +170,14 @@ impl Mode {
         ensures: &[PostCondition],
         statements: &mut Vec<Stmt>,
     ) {
-        let mut clauses: Vec<Expr> = vec![];
-
+        statements.push(parse_quote! {
+            let __anodized_post = true;
+        });
         for condition in maintains {
-            let i = clauses.len();
-            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let eval = build_cond_eval(&condition.expr);
-            statements.push(parse_quote! { let #name = #eval; });
-            clauses.push(parse_quote! { #name });
+            statements.push(parse_quote! {
+                let __anodized_post = #eval;
+            });
         }
 
         {
@@ -198,8 +189,6 @@ impl Mode {
         }
 
         for postcond in ensures {
-            let i = clauses.len();
-            let name = Ident::new(&format!("__anodized_clause_{}", i + 1), Span::mixed_site());
             let expr = &postcond.expr;
             let eval = if let Some(pat) = &postcond.pat {
                 build_cond_eval(&parse_quote! {
@@ -208,20 +197,10 @@ impl Mode {
             } else {
                 build_cond_eval(expr)
             };
-            statements.push(parse_quote! { let #name = #eval; });
-            clauses.push(parse_quote! { #name });
+            statements.push(parse_quote! {
+                let __anodized_post = __anodized_post & #eval;
+            });
         }
-
-        if clauses.is_empty() {
-            clauses.push(parse_quote!(true));
-        }
-
-        statements.push(Stmt::Expr(
-            parse_quote! {
-                #(#clauses)&&*
-            },
-            None,
-        ));
     }
 }
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -164,13 +164,13 @@ impl Mode {
         maintains: &[Condition],
         captures: &[Capture],
         ensures: &[PostCondition],
-    ) -> Result<Block> {
+    ) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
         Self::emit_postcondition_checks(maintains, captures, ensures, &mut stmts);
-        Ok(Block {
+        Block {
             brace_token: Brace(Span::mixed_site()),
             stmts,
-        })
+        }
     }
 
     pub fn emit_postcondition_checks(

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -334,11 +334,8 @@ impl CheckSettings {
         msg: &str,
         cfg: &Option<Meta>,
         expr: &Expr,
-        build_cond_check: F,
-    ) -> Stmt
-    where
-        F: Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
-    {
+        build_cond_check: impl Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+    ) -> Stmt {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
         let check = build_cond_check(msg, cfg, eval, &repr);
@@ -353,11 +350,8 @@ impl CheckSettings {
         cfg: &Option<Meta>,
         tame_pat: &Option<TamePat>,
         expr: &Expr,
-        build_cond_check: F,
-    ) -> Stmt
-    where
-        F: Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
-    {
+        build_cond_check: impl Fn(&str, &Option<Meta>, Expr, &str) -> Expr,
+    ) -> Stmt {
         let repr = expr.to_token_stream().to_string();
         let eval = build_cond_eval(expr);
         let check = build_cond_check(msg, cfg, eval, &repr);

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -141,7 +141,7 @@ impl Mode {
         let output_eval: Expr = parse_quote! {
             ::anodized::__::eval_once(|| { __anodized_output })
         };
-        emit_capture_binding(captures, output_eval, &mut stmts);
+        emit_captures_and_output_binding(captures, output_eval, &mut stmts);
         emit_postcondition_checks(maintains, ensures, &mut stmts, |_, _, cond_eval, _| {
             cond_eval.clone()
         });
@@ -204,7 +204,7 @@ impl CheckSettings {
                 ::anodized::__::eval_once(|| #return_type #original_body)
             }
         };
-        emit_capture_binding(&spec.captures, output_eval, &mut stmts);
+        emit_captures_and_output_binding(&spec.captures, output_eval, &mut stmts);
 
         // Generate postcondition checks.
         emit_postcondition_checks(
@@ -291,7 +291,11 @@ fn emit_precondition_checks(
     }
 }
 
-fn emit_capture_binding(captures: &[Capture], output_eval: Expr, statements: &mut Vec<Stmt>) {
+fn emit_captures_and_output_binding(
+    captures: &[Capture],
+    output_eval: Expr,
+    statements: &mut Vec<Stmt>,
+) {
     let mut patterns = vec![];
     let mut values = vec![];
 

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -220,27 +220,25 @@ impl CheckSettings {
             let __anodized_pre = true;
         }];
         for precondition in &spec.requires {
-            let check =
-                self.build_precond_check(&precondition.cfg, &precondition.expr, |cond, cfg| {
-                    self.build_cond_check(
-                        "precondition failed: {}",
-                        cfg,
-                        cond,
-                        &precondition.expr.to_token_stream().to_string(),
-                    )
-                });
+            let eval = build_cond_eval(&precondition.expr);
+            let check = self.build_cond_check(
+                "precondition failed: {}",
+                &precondition.cfg,
+                &eval,
+                &precondition.expr.to_token_stream().to_string(),
+            );
+            let check = self.build_precond_check(&check);
             precond_checks.push(check);
         }
         for preinvariant in &spec.maintains {
-            let check =
-                self.build_precond_check(&preinvariant.cfg, &preinvariant.expr, |cond, cfg| {
-                    self.build_cond_check(
-                        "preinvariant failed: {}",
-                        cfg,
-                        cond,
-                        &preinvariant.expr.to_token_stream().to_string(),
-                    )
-                });
+            let eval = build_cond_eval(&preinvariant.expr);
+            let check = self.build_cond_check(
+                "preinvariant failed: {}",
+                &preinvariant.cfg,
+                &eval,
+                &preinvariant.expr.to_token_stream().to_string(),
+            );
+            let check = self.build_precond_check(&check);
             precond_checks.push(check);
         }
 
@@ -277,19 +275,14 @@ impl CheckSettings {
             let __anodized_post = true;
         }];
         for postinvariant in &spec.maintains {
-            let check = self.build_postcond_check(
+            let eval = build_cond_eval(&postinvariant.expr);
+            let check = self.build_cond_check(
+                "postinvariant failed: {}",
                 &postinvariant.cfg,
-                &None,
-                &postinvariant.expr,
-                |cond, cfg| {
-                    self.build_cond_check(
-                        "postinvariant failed: {}",
-                        cfg,
-                        cond,
-                        &postinvariant.expr.to_token_stream().to_string(),
-                    )
-                },
+                &eval,
+                &postinvariant.expr.to_token_stream().to_string(),
             );
+            let check = self.build_postcond_check(&None, &check);
             postcond_checks.push(check);
         }
         for postcondition in &spec.ensures {
@@ -298,19 +291,14 @@ impl CheckSettings {
             } else {
                 None
             };
-            let check = self.build_postcond_check(
+            let eval = build_cond_eval(&postcondition.expr);
+            let check = self.build_cond_check(
+                "postcondition failed: {}",
                 &postcondition.cfg,
-                &tame_pat,
-                &postcondition.expr,
-                |cond, cfg| {
-                    self.build_cond_check(
-                        "postcondition failed: {}",
-                        cfg,
-                        cond,
-                        &postcondition.expr.to_token_stream().to_string(),
-                    )
-                },
+                &eval,
+                &postcondition.expr.to_token_stream().to_string(),
             );
+            let check = self.build_postcond_check(&tame_pat, &check);
             postcond_checks.push(check);
         }
 
@@ -347,28 +335,13 @@ impl CheckSettings {
         })
     }
 
-    fn build_precond_check(
-        &self,
-        cfg: &Option<Meta>,
-        expr: &Expr,
-        build_cond_check: impl Fn(&Expr, &Option<Meta>) -> Expr,
-    ) -> Stmt {
-        let eval = build_cond_eval(expr);
-        let check = build_cond_check(&eval, cfg);
+    fn build_precond_check(&self, check: &Expr) -> Stmt {
         parse_quote! {
             let __anodized_pre = __anodized_pre & #check;
         }
     }
 
-    fn build_postcond_check(
-        &self,
-        cfg: &Option<Meta>,
-        tame_pat: &Option<TamePat>,
-        expr: &Expr,
-        build_cond_check: impl Fn(&Expr, &Option<Meta>) -> Expr,
-    ) -> Stmt {
-        let eval = build_cond_eval(expr);
-        let check = build_cond_check(&eval, cfg);
+    fn build_postcond_check(&self, tame_pat: &Option<TamePat>, check: &Expr) -> Stmt {
         match tame_pat {
             Some(TamePat::Borrowing(brw_pat)) => {
                 parse_quote! {

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -158,21 +158,18 @@ impl CheckSettings {
         is_async: bool,
         return_type: &ReturnType,
     ) -> Result<Block> {
-        // The identifier for the return value binding.
-        let output_ident: Pat = parse_quote!(__anodized_output);
-
         let (output_expr, precond_fail_action, postcond_fail_action) =
             if let Some(ref panic_settings) = self.does_panic
                 && panic_settings.has_try_fn
             {
                 (
-                    parse_quote! { Ok(#output_ident) },
+                    parse_quote! { Ok(__anodized_output) },
                     Some(parse_quote! { return ::anodized::result::pre_err(); }),
-                    Some(parse_quote! { return ::anodized::result::post_err(#output_ident); }),
+                    Some(parse_quote! { return ::anodized::result::post_err(__anodized_output); }),
                 )
             } else {
                 (
-                    parse_quote! { #output_ident },
+                    parse_quote! { __anodized_output },
                     self.build_fail_action("precondition failed"),
                     self.build_fail_action("postcondition failed"),
                 )

--- a/crates/anodized-core/src/instrument/fns.rs
+++ b/crates/anodized-core/src/instrument/fns.rs
@@ -121,7 +121,9 @@ impl Mode {
 
     pub fn build_precondition_fn_body(requires: &[Condition], maintains: &[Condition]) -> Block {
         let mut stmts: Vec<Stmt> = vec![];
-        emit_precondition_checks(requires, maintains, &mut stmts, None);
+        emit_precondition_checks(requires, maintains, &mut stmts, |_, _, cond_eval, _| {
+            cond_eval.clone()
+        });
         parse_quote! {
             {
                 #(#stmts)*
@@ -140,7 +142,9 @@ impl Mode {
             ::anodized::__::eval_once(|| { __anodized_output })
         };
         emit_capture_binding(captures, output_eval, &mut stmts);
-        emit_postcondition_checks(maintains, ensures, &mut stmts, None);
+        emit_postcondition_checks(maintains, ensures, &mut stmts, |_, _, cond_eval, _| {
+            cond_eval.clone()
+        });
         parse_quote! {
             {
                 #(#stmts)*
@@ -175,10 +179,6 @@ impl CheckSettings {
                 )
             };
 
-        let instrument_eval = |msg: &str, cfg: &Option<Meta>, cond: &Expr, repr: &str| {
-            self.instrument_cond_eval(msg, cfg, cond, repr)
-        };
-
         let mut stmts: Vec<Stmt> = vec![];
 
         // Generate precondition checks.
@@ -186,7 +186,7 @@ impl CheckSettings {
             &spec.requires,
             &spec.maintains,
             &mut stmts,
-            Some(&instrument_eval),
+            |msg, cfg, cond, repr| self.instrument_cond_eval(msg, cfg, cond, repr),
         );
         stmts.push(parse_quote! {
             if !__anodized_pre {
@@ -211,7 +211,7 @@ impl CheckSettings {
             &spec.maintains,
             &spec.ensures,
             &mut stmts,
-            Some(&instrument_eval),
+            |msg, cfg, cond, repr| self.instrument_cond_eval(msg, cfg, cond, repr),
         );
         stmts.push(parse_quote! {
             if !__anodized_post {
@@ -259,11 +259,14 @@ impl CheckSettings {
     }
 }
 
+trait FnInstrumentEval: Fn(&str, &Option<Meta>, &Expr, &str) -> Expr {}
+impl<F> FnInstrumentEval for F where F: Fn(&str, &Option<Meta>, &Expr, &str) -> Expr {}
+
 fn emit_precondition_checks(
     requires: &[Condition],
     maintains: &[Condition],
     statements: &mut Vec<Stmt>,
-    maybe_instrument_eval: Option<&dyn Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+    instrument_eval: impl FnInstrumentEval,
 ) {
     statements.push(parse_quote! {
         let __anodized_pre = true;
@@ -271,24 +274,18 @@ fn emit_precondition_checks(
 
     for precondition in requires {
         let eval = build_cond_eval(&precondition.expr);
-        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-            let repr = precondition.expr.to_token_stream().to_string();
-            instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr)
-        } else {
-            eval
-        };
+        let repr = precondition.expr.to_token_stream().to_string();
+        let instrumented_eval =
+            instrument_eval("precondition failed: {}", &precondition.cfg, &eval, &repr);
         let check = build_precond_check(&instrumented_eval);
         statements.push(check);
     }
 
     for preinvariant in maintains {
         let eval = build_cond_eval(&preinvariant.expr);
-        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-            let repr = preinvariant.expr.to_token_stream().to_string();
-            instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr)
-        } else {
-            eval
-        };
+        let repr = preinvariant.expr.to_token_stream().to_string();
+        let instrumented_eval =
+            instrument_eval("preinvariant failed: {}", &preinvariant.cfg, &eval, &repr);
         let check = build_precond_check(&instrumented_eval);
         statements.push(check);
     }
@@ -321,7 +318,7 @@ fn emit_postcondition_checks(
     maintains: &[Condition],
     ensures: &[PostCondition],
     statements: &mut Vec<Stmt>,
-    maybe_instrument_eval: Option<&dyn Fn(&str, &Option<Meta>, &Expr, &str) -> Expr>,
+    instrument_eval: impl FnInstrumentEval,
 ) {
     statements.push(parse_quote! {
         let __anodized_post = true;
@@ -329,24 +326,18 @@ fn emit_postcondition_checks(
 
     for postinvariant in maintains {
         let eval = build_cond_eval(&postinvariant.expr);
-        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-            let repr = postinvariant.expr.to_token_stream().to_string();
-            instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr)
-        } else {
-            eval
-        };
+        let repr = postinvariant.expr.to_token_stream().to_string();
+        let instrumented_eval =
+            instrument_eval("postinvariant failed: {}", &postinvariant.cfg, &eval, &repr);
         let check = build_postcond_check(&None, &instrumented_eval);
         statements.push(check);
     }
 
     for postcondition in ensures {
         let eval = build_cond_eval(&postcondition.expr);
-        let instrumented_eval = if let Some(instrument_eval) = maybe_instrument_eval {
-            let repr = postcondition.expr.to_token_stream().to_string();
-            instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr)
-        } else {
-            eval
-        };
+        let repr = postcondition.expr.to_token_stream().to_string();
+        let instrumented_eval =
+            instrument_eval("postcondition failed: {}", &postcondition.cfg, &eval, &repr);
         let check = build_postcond_check(&postcondition.pat, &instrumented_eval);
         statements.push(check);
     }

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -64,9 +64,18 @@ fn embed_spec_item_fn() {
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
             );
-            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
-            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
-            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
+            let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_7), PAT_1),
+                __anodized_output,
+            );
+            let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_8), PAT_1),
+                __anodized_output,
+            );
+            let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_9), PAT_1),
+                __anodized_output,
+            );
             __anodized_post
         }
 

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -57,9 +57,9 @@ fn embed_spec_item_fn() {
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
             let __anodized_post = true;
-            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_4);
-            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_5);
-            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_6);
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_4);
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_5);
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_6);
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -230,7 +230,7 @@ fn simple_requires() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             if !__anodized_post {
                 panic!("postcondition failed");
@@ -270,7 +270,7 @@ fn requires_disable_runtime_checks() {
             let __anodized_pre = true;
             let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| CONDITION_1));
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -292,7 +292,7 @@ fn requires_no_panic_runtime() {
             let __anodized_pre = __anodized_pre & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("precondition failed: {}", "CONDITION_1") != ());
             if !__anodized_pre {}
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             if !__anodized_post {}
             __anodized_output
@@ -325,7 +325,7 @@ fn simple_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -360,7 +360,7 @@ fn simple_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -402,7 +402,7 @@ fn simple_requires_and_maintains() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -442,7 +442,7 @@ fn simple_requires_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postcondition failed: {}", "CONDITION_2") != ());
@@ -482,7 +482,7 @@ fn simple_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postinvariant failed: {}", "CONDITION_1") != ());
@@ -527,7 +527,7 @@ fn simple_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -572,7 +572,7 @@ fn simple_async_requires_maintains_and_ensures() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(async || -> RET_TYPE { BODY }).await);
+            let __anodized_output = ::anodized::__::eval_once(async || -> RET_TYPE { BODY }).await;
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -621,7 +621,7 @@ fn multiple_conditions_in_clauses() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_3)
                 || eprintln!("postinvariant failed: {}", "CONDITION_3") != ());
@@ -662,7 +662,7 @@ fn postcond_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |OUTPUT_PATTERN| (__anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
@@ -700,7 +700,7 @@ fn postcond_borrowing_closure_form() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |__anodized_output| {
@@ -748,7 +748,7 @@ fn ensures_with_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_1)
                 || eprintln!("postcondition failed: {}", "CONDITION_1") != ());
@@ -800,7 +800,7 @@ fn cfg_attributes() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (!cfg!(SETTING_2) || ::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -849,7 +849,7 @@ fn cfg_on_single_and_list_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_2)
                 || eprintln!("postinvariant failed: {}", "CONDITION_2") != ());
@@ -912,7 +912,7 @@ fn complex_mixed_conditions() {
             if !__anodized_pre {
                 panic!("precondition failed");
             }
-            let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+            let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
             let __anodized_post = true;
             let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| CONDITION_4)
                 || eprintln!("postinvariant failed: {}", "CONDITION_4") != ());

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -56,14 +56,15 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
+            let (ALIAS_1, (ALIAS_2, ALIAS_3), __anodized_output) = (
+                ::anodized::__::eval(|| EXPR_1),
+                ::anodized::__::eval(|| EXPR_2),
+                ::anodized::__::eval_once(|| { __anodized_output }),
+            );
             let __anodized_post = true;
             let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_4);
             let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_5);
             let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_6);
-            let (ALIAS_1, (ALIAS_2, ALIAS_3)) = (
-                ::anodized::__::eval(|| EXPR_1),
-                ::anodized::__::eval(|| EXPR_2),
-            );
             let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                 |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_7), PAT_1),
                 __anodized_output,

--- a/crates/anodized-core/src/instrument/fns_tests.rs
+++ b/crates/anodized-core/src/instrument/fns_tests.rs
@@ -43,31 +43,31 @@ fn embed_spec_item_fn() {
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| COND_3);
-            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| COND_4);
-            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| COND_5);
-            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| COND_6);
-            __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
-                && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
+            let __anodized_pre = true;
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_3);
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_4);
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_5);
+            let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_6);
+            __anodized_pre
         }
 
         #[doc(hidden)]
         #[allow(warnings)]
         fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-            let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_4);
-            let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_5);
-            let __anodized_clause_3 = ::anodized::__::eval::<bool>(|| COND_6);
+            let __anodized_post = true;
+            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_4);
+            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_5);
+            let __anodized_post = ::anodized::__::eval::<bool>(|| COND_6);
             let (ALIAS_1, (ALIAS_2, ALIAS_3)) = (
                 ::anodized::__::eval(|| EXPR_1),
                 ::anodized::__::eval(|| EXPR_2),
             );
-            let __anodized_clause_4 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
-            let __anodized_clause_5 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
-            let __anodized_clause_6 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
-            __anodized_clause_1 && __anodized_clause_2 && __anodized_clause_3
-                && __anodized_clause_4 && __anodized_clause_5 && __anodized_clause_6
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_7 });
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_8 });
+            let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_9 });
+            __anodized_post
         }
 
         fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/impls.rs
+++ b/crates/anodized-core/src/instrument/impls.rs
@@ -74,7 +74,7 @@ Instead, ensure that both the impl block and the fn have a `#[spec]` annotation.
                                 &fn_spec.maintains,
                                 &fn_spec.captures,
                                 &fn_spec.ensures,
-                            )?,
+                            ),
                             vis: Visibility::Inherited,
                             defaultness: None,
                         };

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -44,7 +44,7 @@ fn embed_spec_item_impl() {
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
                 let __anodized_post = true;
-                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_post

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -88,7 +88,7 @@ fn default_instrument_item_impl() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
@@ -151,7 +151,7 @@ fn emit_try_fn_instrument_item_impl() {
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
                 }
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -43,9 +43,7 @@ fn embed_spec_item_impl() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let (__anodized_output,) = (
-                    ::anodized::__::eval_once(|| { __anodized_output }),
-                );
+                let __anodized_output = ::anodized::__::eval_once(|| { __anodized_output });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -43,9 +43,11 @@ fn embed_spec_item_impl() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
+                let (__anodized_output,) = (
+                    ::anodized::__::eval_once(|| { __anodized_output }),
+                );
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
-                let () = ();
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                     |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
                     __anodized_output,

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -46,7 +46,10 @@ fn embed_spec_item_impl() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                    |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
+                    __anodized_output,
+                );
                 __anodized_post
             }
 

--- a/crates/anodized-core/src/instrument/impls_tests.rs
+++ b/crates/anodized-core/src/instrument/impls_tests.rs
@@ -34,18 +34,20 @@ fn embed_spec_item_impl() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                __anodized_pre
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = true;
+                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                __anodized_post
             }
 
             fn FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> RET_TYPE {

--- a/crates/anodized-core/src/instrument/loops_tests.rs
+++ b/crates/anodized-core/src/instrument/loops_tests.rs
@@ -21,9 +21,10 @@ fn embed_spec_expr_while() {
     let expected: TokenStream = parse_quote! {
         while WHILE_COND {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| INVAR_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| INVAR_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| INVAR_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| INVAR_2);
+                __anodized_pre
             };
             let __anodized_loop_decreases = || {
                 let __anodized_value_1 = (|| DECREASES_1)();
@@ -57,9 +58,10 @@ fn embed_spec_expr_for() {
     let expected: TokenStream = parse_quote! {
         for FOR_VAR in FOR_EXPR {
             let __anodized_loop_maintains = || -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| INVAR_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| INVAR_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| INVAR_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| INVAR_2);
+                __anodized_pre
             };
             let __anodized_loop_decreases = || {};
             LOOP_BODY

--- a/crates/anodized-core/src/instrument/patterns.rs
+++ b/crates/anodized-core/src/instrument/patterns.rs
@@ -6,7 +6,7 @@ use syn::{Expr, Ident, Pat, PatIdent, parse_quote, visit_mut::VisitMut};
 mod patterns_tests;
 
 /// A 'tame' pattern can be used inside a `#[spec]`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TamePat {
     /// The pattern binds only by `ref`. It may contain wildcard (`_`) and rest (`..`) patterns.
     Borrowing(Pat),

--- a/crates/anodized-core/src/instrument/traits.rs
+++ b/crates/anodized-core/src/instrument/traits.rs
@@ -69,7 +69,7 @@ impl Mode {
                                 &fn_spec.maintains,
                                 &fn_spec.captures,
                                 &fn_spec.ensures,
-                            )?),
+                            )),
                             semi_token: None,
                         };
 
@@ -240,7 +240,7 @@ Instead, ensure that both the trait and the impl fn have a `#[spec]` annotation.
                                 &fn_spec.maintains,
                                 &fn_spec.captures,
                                 &fn_spec.ensures,
-                            )?,
+                            ),
                             vis: Visibility::Inherited,
                             defaultness: None,
                         };

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -106,7 +106,7 @@ fn default_instrument_item_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
@@ -182,7 +182,7 @@ fn emit_try_fn_instrument_item_trait() {
                 if !__anodized_pre {
                     return ::anodized::result::pre_err();
                 }
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { Self::__anodized_FUNC(self, PARAM_1, PARAM_2) });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());
@@ -299,7 +299,7 @@ fn default_instrument_item_impl_trait() {
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_1));
                 let __anodized_pre = __anodized_pre & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 if !__anodized_pre {}
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (true || ::anodized::__::eval::<bool>(|| COND_2));
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
@@ -359,7 +359,7 @@ fn emit_try_fn_instrument_item_impl_trait() {
                 if !__anodized_pre {
                     panic!("precondition failed");
                 }
-                let (__anodized_output) = (::anodized::__::eval_once(|| -> RET_TYPE { BODY }));
+                let __anodized_output = ::anodized::__::eval_once(|| -> RET_TYPE { BODY });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & (::anodized::__::eval::<bool>(|| COND_2)
                         || eprintln!("postinvariant failed: {}", "COND_2") != ());

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -40,7 +40,7 @@ fn embed_spec_item_trait() {
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
                 let __anodized_post = true;
-                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_post
@@ -234,7 +234,7 @@ fn embed_spec_item_impl_trait() {
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
                 let __anodized_post = true;
-                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
                 __anodized_post

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -42,7 +42,10 @@ fn embed_spec_item_trait() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                    |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
+                    __anodized_output,
+                );
                 __anodized_post
             }
 
@@ -236,7 +239,10 @@ fn embed_spec_item_impl_trait() {
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
+                    |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
+                    __anodized_output,
+                );
                 __anodized_post
             }
 

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -39,9 +39,11 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
+                let (__anodized_output,) = (
+                    ::anodized::__::eval_once(|| { __anodized_output }),
+                );
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
-                let () = ();
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                     |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
                     __anodized_output,
@@ -236,9 +238,11 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
+                let (__anodized_output,) = (
+                    ::anodized::__::eval_once(|| { __anodized_output }),
+                );
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
-                let () = ();
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
                     |PAT_1| (__anodized_post & ::anodized::__::eval::<bool>(|| COND_3), PAT_1),
                     __anodized_output,

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -39,9 +39,7 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let (__anodized_output,) = (
-                    ::anodized::__::eval_once(|| { __anodized_output }),
-                );
+                let __anodized_output = ::anodized::__::eval_once(|| { __anodized_output });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(
@@ -238,9 +236,7 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let (__anodized_output,) = (
-                    ::anodized::__::eval_once(|| { __anodized_output }),
-                );
+                let __anodized_output = ::anodized::__::eval_once(|| { __anodized_output });
                 let __anodized_post = true;
                 let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| COND_2);
                 let (__anodized_post, __anodized_output) = ::anodized::__::apply_keep(

--- a/crates/anodized-core/src/instrument/traits_tests.rs
+++ b/crates/anodized-core/src/instrument/traits_tests.rs
@@ -30,18 +30,20 @@ fn embed_spec_item_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                __anodized_pre
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = true;
+                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                __anodized_post
             }
 
             #[doc(hidden)]
@@ -222,18 +224,20 @@ fn embed_spec_item_impl_trait() {
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_requires_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_1);
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| COND_2);
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_pre = true;
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_1);
+                let __anodized_pre = __anodized_pre & ::anodized::__::eval::<bool>(|| COND_2);
+                __anodized_pre
             }
 
             #[doc(hidden)]
             #[allow(warnings)]
             fn __anodized_fn_ensures_FUNC(&self, PARAM_1: TYPE_1, PARAM_2: TYPE_2, __anodized_output: RET_TYPE) -> bool {
-                let __anodized_clause_1 = ::anodized::__::eval::<bool>(|| COND_2);
+                let __anodized_post = true;
+                let __anodized_post = ::anodized::__::eval::<bool>(|| COND_2);
                 let () = ();
-                let __anodized_clause_2 = ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
-                __anodized_clause_1 && __anodized_clause_2
+                let __anodized_post = __anodized_post & ::anodized::__::eval::<bool>(|| { let PAT_1 = __anodized_output; COND_3 });
+                __anodized_post
             }
 
             #[doc(hidden)]

--- a/crates/anodized-core/src/lib.rs
+++ b/crates/anodized-core/src/lib.rs
@@ -3,7 +3,7 @@
 use proc_macro2::Span;
 use syn::{Error, Expr, Meta, Pat};
 
-use crate::qualifiers::FnQualifiers;
+use crate::{instrument::patterns::TamePat, qualifiers::FnQualifiers};
 
 pub mod annotate;
 pub mod instrument;
@@ -153,7 +153,7 @@ pub struct Condition {
 #[derive(Debug)]
 pub struct PostCondition {
     /// The pattern to bind or destructure the function's output, e.g. `answer` or `(left, right)`.
-    pub pat: Option<Pat>,
+    pub pat: Option<TamePat>,
     /// The expression that validates the postcondition, e.g. `answer == "forty-two"`.
     pub expr: Expr,
     /// **Static analyzers can safely ignore this field.**

--- a/crates/anodized/tests/condition_cfg.rs
+++ b/crates/anodized/tests/condition_cfg.rs
@@ -11,7 +11,7 @@ use anodized::spec;
     #[cfg(any())]
     requires: false,
 )]
-fn gated_off_precondition(value: i32) -> i32 {
+pub fn gated_off_precondition(value: i32) -> i32 {
     value
 }
 
@@ -19,7 +19,7 @@ fn gated_off_precondition(value: i32) -> i32 {
     #[cfg(all())]
     requires: false,
 )]
-fn gated_on_precondition(value: i32) -> i32 {
+pub fn gated_on_precondition(value: i32) -> i32 {
     value
 }
 
@@ -27,7 +27,7 @@ fn gated_on_precondition(value: i32) -> i32 {
     #[cfg(any())]
     ensures: |output| output == value + 1,
 )]
-fn gated_off_postcondition(value: i32) -> i32 {
+pub fn gated_off_postcondition(value: i32) -> i32 {
     value
 }
 
@@ -35,7 +35,7 @@ fn gated_off_postcondition(value: i32) -> i32 {
     #[cfg(all())]
     ensures: |output| output == value + 1,
 )]
-fn gated_on_postcondition(value: i32) -> i32 {
+pub fn gated_on_postcondition(value: i32) -> i32 {
     value
 }
 

--- a/crates/anodized/tests/id_mut_ref.rs
+++ b/crates/anodized/tests/id_mut_ref.rs
@@ -2,6 +2,6 @@
 use anodized::spec;
 
 #[spec]
-fn id(x: &mut i32) -> &mut i32 {
+pub fn id(x: &mut i32) -> &mut i32 {
     x
 }

--- a/crates/anodized/tests/output_patterns.rs
+++ b/crates/anodized/tests/output_patterns.rs
@@ -7,7 +7,7 @@ use anodized::spec;
     ],
 )]
 #[allow(unused)]
-fn sort_pair_i32(pair: (i32, i32)) -> (i32, i32) {
+pub fn sort_pair_i32(pair: (i32, i32)) -> (i32, i32) {
     // Deliberately wrong implementation to break the spec.
     pair
 }
@@ -15,7 +15,7 @@ fn sort_pair_i32(pair: (i32, i32)) -> (i32, i32) {
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
 #[should_panic(expected = "postcondition failed")]
-fn sort_pair_i32_fail_postcondition() {
+pub fn sort_pair_i32_fail_postcondition() {
     sort_pair_i32((5, 2));
 }
 
@@ -24,7 +24,7 @@ fn sort_pair_i32_fail_postcondition() {
     ensures: |(a, b)| a <= b,
 )]
 #[allow(unused)]
-fn sort_pair<T: Ord>(pair: (T, T)) -> (T, T) {
+pub fn sort_pair<T: Ord>(pair: (T, T)) -> (T, T) {
     // Deliberately wrong implementation to break the spec.
     pair
 }
@@ -32,13 +32,13 @@ fn sort_pair<T: Ord>(pair: (T, T)) -> (T, T) {
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
 #[should_panic(expected = "postcondition failed")]
-fn sort_pair_fail_postcondition() {
+pub fn sort_pair_fail_postcondition() {
     sort_pair((5, 2));
 }
 
 #[spec(ensures: |(mut a, b)| a <= b)]
 #[allow(unused_mut)]
-fn sort_pair_with_mut_binding(pair: (i32, i32)) -> (i32, i32) {
+pub fn sort_pair_with_mut_binding(pair: (i32, i32)) -> (i32, i32) {
     // Deliberately wrong implementation to break the spec.
     pair
 }
@@ -46,12 +46,12 @@ fn sort_pair_with_mut_binding(pair: (i32, i32)) -> (i32, i32) {
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
 #[should_panic(expected = "postcondition failed")]
-fn output_pattern_with_mut_binding() {
+pub fn output_pattern_with_mut_binding() {
     sort_pair_with_mut_binding((5, 2));
 }
 
 #[spec(ensures: |pair @ (a, b)| a <= b)]
-fn sort_pair_with_at_binding(pair: (i32, i32)) -> (i32, i32) {
+pub fn sort_pair_with_at_binding(pair: (i32, i32)) -> (i32, i32) {
     // Deliberately wrong implementation to break the spec.
     pair
 }
@@ -59,6 +59,6 @@ fn sort_pair_with_at_binding(pair: (i32, i32)) -> (i32, i32) {
 #[cfg(all(anodized_print, anodized_panic))]
 #[test]
 #[should_panic(expected = "postcondition failed")]
-fn output_pattern_with_at_binding() {
+pub fn output_pattern_with_at_binding() {
     sort_pair_with_at_binding((5, 2));
 }


### PR DESCRIPTION
- Bring instrumentation and spec embedding back in sync.
- Share machinery between `fn build_pre/postcondition_fn_body` and `fn instrument_fn_body`.
  - Share building precondition checks as `fn emit_precondition_checks`.
  - Share building the captures-and-output binding as `fn emit_captures_and_output_binding`.
  - Share building postcondition checks as `fn emit_postcondition_checks`.
- "Tame" patterns during parsing, i.e. process each postcondition's `Pat` into a `TamePat`.
- Remove unnecessary `Result` from the return type of `fn build_postcondition_fn_body`.
- Update tests.